### PR TITLE
Add auto-update via NetSparkleUpdater with custom dark-themed dialogs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*.*'
+
+jobs:
+  release:
+    runs-on: macos-latest
+
+    env:
+      EnableWindowsTargeting: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Extract version
+        id: version
+        run: |
+          VER=$(sed -n 's/.*AssemblyFileVersion("\([^"]*\)").*/\1/p' EmoTracker/Properties/AssemblyInfo.cs)
+          echo "app_version=$VER" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VER"
+
+      - name: Publish win-x64
+        run: dotnet publish EmoTracker/EmoTracker.csproj --framework net8.0 --configuration Release --runtime win-x64 --self-contained --output publish/win-x64
+
+      - name: Publish osx-x64
+        run: dotnet publish EmoTracker/EmoTracker.csproj --framework net8.0 --configuration Release --runtime osx-x64 --self-contained --output publish/osx-x64
+
+      - name: Publish osx-arm64
+        run: dotnet publish EmoTracker/EmoTracker.csproj --framework net8.0 --configuration Release --runtime osx-arm64 --self-contained --output publish/osx-arm64
+
+      - name: Publish linux-x64
+        run: dotnet publish EmoTracker/EmoTracker.csproj --framework net8.0 --configuration Release --runtime linux-x64 --self-contained --output publish/linux-x64
+
+      - name: Create universal macOS binary
+        run: |
+          mkdir -p publish/universal
+          cp -R publish/osx-arm64/* publish/universal/
+          cd publish
+          find osx-arm64 -type f | while read arm64_file; do
+            rel="${arm64_file#osx-arm64/}"
+            x64_file="osx-x64/$rel"
+            universal_file="universal/$rel"
+            if [ ! -f "$x64_file" ]; then continue; fi
+            if file "$arm64_file" | grep -q "Mach-O"; then
+              arm64_archs=$(lipo -archs "$arm64_file" 2>/dev/null || true)
+              x64_archs=$(lipo -archs "$x64_file" 2>/dev/null || true)
+              if [ "$arm64_archs" != "$x64_archs" ]; then
+                echo "Creating universal binary: $rel"
+                lipo -create "$arm64_file" "$x64_file" -output "$universal_file"
+              fi
+            fi
+          done
+
+      - name: Create macOS app bundle
+        run: |
+          VER="${{ steps.version.outputs.app_version }}"
+          APP="publish/EmoTracker.app"
+          mkdir -p "$APP/Contents/MacOS"
+          mkdir -p "$APP/Contents/Resources"
+          cp -R publish/universal/* "$APP/Contents/MacOS/"
+          cp EmoTracker/macOS/Info.plist "$APP/Contents/"
+          chmod +x "$APP/Contents/MacOS/EmoTracker"
+
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install --quiet Pillow
+          python3 -c "
+          from PIL import Image, ImageDraw
+          import os
+          ico = Image.open('EmoTracker/emohead_icon_transparent_7h3_icon.ico')
+          best = None
+          for size in sorted(ico.info.get('sizes', [(ico.width, ico.height)]), reverse=True):
+              ico.size = size
+              candidate = ico.copy().convert('RGBA')
+              if best is None or candidate.width > best.width:
+                  best = candidate
+          src = best
+          iconset = 'EmoTracker.iconset'
+          os.makedirs(iconset, exist_ok=True)
+          def make_icon(src, s):
+              bg = Image.new('RGBA', (s, s), (0, 0, 0, 0))
+              draw = ImageDraw.Draw(bg)
+              r = max(s // 5, 4)
+              draw.rounded_rectangle([0, 0, s - 1, s - 1], radius=r, fill=(0, 0, 0, 255))
+              resized = src.resize((s, s), Image.LANCZOS)
+              bg.paste(resized, (0, 0), resized)
+              return bg
+          sizes = [16, 32, 64, 128, 256, 512]
+          for s in sizes:
+              icon = make_icon(src, s)
+              icon.save(os.path.join(iconset, f'icon_{s}x{s}.png'))
+              if s >= 32:
+                  half = s // 2
+                  icon.save(os.path.join(iconset, f'icon_{half}x{half}@2x.png'))
+          icon = make_icon(src, 1024)
+          icon.save(os.path.join(iconset, 'icon_512x512@2x.png'))
+          "
+          iconutil -c icns EmoTracker.iconset -o "$APP/Contents/Resources/EmoTracker.icns"
+          codesign --force --deep -s - "$APP"
+
+      - name: Package artifacts
+        run: |
+          VER="${{ steps.version.outputs.app_version }}"
+          mkdir -p dist
+
+          # Windows zip
+          cd publish/win-x64
+          zip -r "../../dist/EmoTracker-${VER}-win-x64.zip" .
+          cd ../..
+
+          # macOS tar.gz
+          tar czf "dist/EmoTracker-${VER}-osx-universal.tar.gz" -C publish EmoTracker.app
+
+          # Linux tar.xz
+          chmod +x publish/linux-x64/EmoTracker
+          tar cJf "dist/EmoTracker-${VER}-linux-x64.tar.xz" -C publish/linux-x64 .
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VER="${{ steps.version.outputs.app_version }}"
+          TAG="${{ github.ref_name }}"
+          gh release create "$TAG" \
+            --title "EmoTracker $VER" \
+            --notes "See the [changelog](https://github.com/EmoTracker-Community/EmoTracker/releases/tag/$TAG) for details." \
+            dist/EmoTracker-${VER}-win-x64.zip \
+            dist/EmoTracker-${VER}-osx-universal.tar.gz \
+            dist/EmoTracker-${VER}-linux-x64.tar.xz

--- a/EmoTracker.Data/ApplicationSettings.cs
+++ b/EmoTracker.Data/ApplicationSettings.cs
@@ -43,6 +43,7 @@ namespace EmoTracker.Data
         double mNDIFrameRate = 30.0;
         int mNDIOutputScale = 1;
         bool mbEnableBackgroundNdi = true;
+        bool mbEnableAutoUpdateCheck = true;
         bool mbAlwaysOnTop = false;
         bool mbEnableDiscordRichPresence = false;
         bool mbEnableVoice = true;
@@ -220,6 +221,12 @@ namespace EmoTracker.Data
             set { SetProperty(ref mbEnableBackgroundNdi, value); }
         }
 
+        public bool EnableAutoUpdateCheck
+        {
+            get { return mbEnableAutoUpdateCheck; }
+            set { SetProperty(ref mbEnableAutoUpdateCheck, value); }
+        }
+
         public IEnumerable<string> AdditionalRepositories
         {
             get { return mPackageRepositories; }
@@ -258,6 +265,7 @@ namespace EmoTracker.Data
                         NdiFrameRate = root.GetValue<double>("ndi_frame_rate", 30.0);
                         NdiOutputScale = root.GetValue<int>("ndi_output_scale", 1);
                         EnableBackgroundNdi = root.GetValue<bool>("enable_background_ndi", true);
+                        EnableAutoUpdateCheck = root.GetValue<bool>("enable_auto_update_check", true);
                         AlwaysOnTop = root.GetValue<bool>("always_on_top", false);
                         EnableDiscordRichPresence = root.GetValue<bool>("discord_rich_presence", false);
                         EnableVoiceControl = root.GetValue<bool>("enable_voice_control", true);
@@ -355,6 +363,7 @@ namespace EmoTracker.Data
                             root.Add("ndi_output_scale", JToken.FromObject(NdiOutputScale));
 
                         root.Add("enable_background_ndi", JToken.FromObject(EnableBackgroundNdi));
+                        root.Add("enable_auto_update_check", JToken.FromObject(EnableAutoUpdateCheck));
 
                         root.Add("always_on_top", JToken.FromObject(AlwaysOnTop));
                         root.Add("discord_rich_presence", JToken.FromObject(EnableDiscordRichPresence));

--- a/EmoTracker.UI/EmoTracker.UI.csproj
+++ b/EmoTracker.UI/EmoTracker.UI.csproj
@@ -27,10 +27,10 @@
 
   <!-- Avalonia packages — Phase 5 implementation -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Avalonia" Version="11.2.7" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.7" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.7" />
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.2.7" />
+    <PackageReference Include="Avalonia" Version="11.3.3" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.3" />
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.3.0.6" />
     <PackageReference Include="Markdig" Version="0.37.0" />
     <PackageReference Include="Markdown.Avalonia" Version="11.0.2" />
     <PackageReference Include="SkiaSharp" Version="2.88.9" />

--- a/EmoTracker/App.axaml.cs
+++ b/EmoTracker/App.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using EmoTracker.Core;
 using EmoTracker.Services;
+using EmoTracker.Services.Updates;
 using Serilog;
 using Serilog.Events;
 using System;
@@ -54,6 +55,7 @@ namespace EmoTracker
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
                 desktop.MainWindow = new MainWindow();
+                UpdateService.Instance.StartBackgroundCheck();
 
                 desktop.Exit += (s, e) =>
                 {

--- a/EmoTracker/EmoTracker.csproj
+++ b/EmoTracker/EmoTracker.csproj
@@ -74,6 +74,7 @@
     <PackageReference Include="NDILibDotNetCoreBase" Version="2024.7.22.1" />
     <PackageReference Include="NetSparkleUpdater.SparkleUpdater" Version="3.0.4" />
     <PackageReference Include="NetSparkleUpdater.UI.Avalonia" Version="3.0.4" />
+    <PackageReference Include="Markdig" Version="0.38.0" />
   </ItemGroup>
 
   <!-- Shared packages (both targets) -->

--- a/EmoTracker/EmoTracker.csproj
+++ b/EmoTracker/EmoTracker.csproj
@@ -65,13 +65,15 @@
 
   <!-- Avalonia packages (cross-platform target) -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Avalonia" Version="11.2.7" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.7" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.7" />
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.2.7" />
+    <PackageReference Include="Avalonia" Version="11.3.3" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.3" />
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.3.0.6" />
     <PackageReference Include="MsBox.Avalonia" Version="3.0.0-rc2" />
     <!-- NDI cross-platform P/Invoke wrapper (net8.0 port of NDILibDotNet2) -->
     <PackageReference Include="NDILibDotNetCoreBase" Version="2024.7.22.1" />
+    <PackageReference Include="NetSparkleUpdater.SparkleUpdater" Version="3.0.4" />
+    <PackageReference Include="NetSparkleUpdater.UI.Avalonia" Version="3.0.4" />
   </ItemGroup>
 
   <!-- Shared packages (both targets) -->

--- a/EmoTracker/MainWindow.axaml
+++ b/EmoTracker/MainWindow.axaml
@@ -156,6 +156,8 @@
                                           IsChecked="{Binding FastToolTips, Mode=TwoWay, Source={x:Static data:ApplicationSettings.Instance}}" />
                             </MenuItem>
                             <Separator />
+                            <MenuItem Header="Check for Updates…" Name="CheckForUpdatesMenuItem" />
+                            <Separator />
                             <MenuItem Header="Advanced">
                                 <MenuItem Header="Export Overrides" Command="{Binding ExportPackageOverrideCommand, Source={x:Static local:ApplicationModel.Instance}}" />
                                 <Separator />

--- a/EmoTracker/MainWindow.axaml.cs
+++ b/EmoTracker/MainWindow.axaml.cs
@@ -6,6 +6,7 @@ using EmoTracker.Data;
 using EmoTracker.Data.Core.Transactions;
 using EmoTracker.Data.Core.Transactions.Processors;
 using EmoTracker.Data.Layout;
+using EmoTracker.Services.Updates;
 using System;
 using System.ComponentModel;
 using System.Linq;
@@ -44,10 +45,18 @@ namespace EmoTracker
             if (this.FindControl<Button>("SettingsButton") is Button settingsBtn)
                 settingsBtn.Click += SettingsButton_Click;
 
+            if (this.FindControl<MenuItem>("CheckForUpdatesMenuItem") is MenuItem checkUpdatesItem)
+                checkUpdatesItem.Click += CheckForUpdatesMenuItem_Click;
+
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
             {
                 TrackerLayout?.Focus();
             });
+        }
+
+        private async void CheckForUpdatesMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            await UpdateService.Instance.CheckAndShowUpdateWindowAsync();
         }
 
         private void SettingsButton_Click(object sender, RoutedEventArgs e)

--- a/EmoTracker/Services/Updates/EmoTrackerUIFactory.cs
+++ b/EmoTracker/Services/Updates/EmoTrackerUIFactory.cs
@@ -1,0 +1,38 @@
+using Avalonia.Controls;
+using Avalonia.Threading;
+using EmoTracker.UI;
+using NetSparkleUpdater;
+using NetSparkleUpdater.Interfaces;
+using NetSparkleUpdater.UI.Avalonia;
+using System.Collections.Generic;
+
+namespace EmoTracker.Services.Updates
+{
+    /// <summary>
+    /// Custom <see cref="UIFactory"/> that substitutes EmoTracker-styled windows for
+    /// the "Checking for updates" and "Update available" dialogs while inheriting the
+    /// built-in download-progress and error windows from the base class.
+    /// </summary>
+    public class EmoTrackerUIFactory : UIFactory
+    {
+        public EmoTrackerUIFactory() : base(null) { }
+
+        public override ICheckingForUpdates ShowCheckingForUpdates()
+        {
+            var window = new EmoCheckingForUpdatesWindow();
+            Dispatcher.UIThread.Post(() => window.Show());
+            return window;
+        }
+
+        public override IUpdateAvailable CreateUpdateAvailableWindow(
+            List<AppCastItem> updates,
+            ISignatureVerifier signatureVerifier,
+            string currentVersion,
+            string appName,
+            bool isUpdateAlreadyDownloaded)
+        {
+            var window = new EmoUpdateAvailableWindow(updates, currentVersion, appName);
+            return window;
+        }
+    }
+}

--- a/EmoTracker/Services/Updates/GitHubAppCastDataDownloader.cs
+++ b/EmoTracker/Services/Updates/GitHubAppCastDataDownloader.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
@@ -85,8 +86,16 @@ namespace EmoTracker.Services.Updates
                     return EmptyAppCast();
                 }
 
-                string releaseJson = doc.RootElement[0].GetRawText();
-                string appcast = BuildAppCastXml(releaseJson);
+                var releaseElement = doc.RootElement[0];
+                string releaseJson = releaseElement.GetRawText();
+
+                // Render the release body markdown to HTML via the GitHub Markdown API.
+                string bodyMarkdown = releaseElement.TryGetProperty("body", out var bodyProp)
+                    ? bodyProp.GetString() ?? string.Empty
+                    : string.Empty;
+                string releaseNotesHtml = await RenderMarkdownAsync(bodyMarkdown).ConfigureAwait(false);
+
+                string appcast = BuildAppCastXml(releaseJson, releaseNotesHtml);
                 Log.Debug("[Update] Generated appcast XML:\n{Appcast}", appcast);
                 return appcast;
             }
@@ -97,12 +106,42 @@ namespace EmoTracker.Services.Updates
             }
         }
 
+        /// <summary>
+        /// Calls the GitHub Markdown API to render <paramref name="markdown"/> as HTML.
+        /// Falls back to a plain-text preformatted block on any error.
+        /// </summary>
+        private async Task<string> RenderMarkdownAsync(string markdown)
+        {
+            if (string.IsNullOrWhiteSpace(markdown))
+                return string.Empty;
+            try
+            {
+                // Use GFM mode with the repo context so issue/PR references resolve.
+                var payload = new
+                {
+                    text    = markdown,
+                    mode    = "gfm",
+                    context = $"{_repoOwner}/{_repoName}"
+                };
+                using var response = await Http
+                    .PostAsJsonAsync($"{ApiBase}/markdown", payload)
+                    .ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
+                return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[Update] Failed to render release notes markdown; falling back to plain text.");
+                return $"<pre>{EscapeXml(markdown)}</pre>";
+            }
+        }
+
         // Returns the encoding used by the app cast data (UTF-8).
         public Encoding GetAppCastEncoding() => Encoding.UTF8;
 
         // -----------------------------------------------------------------------
 
-        private string BuildAppCastXml(string releaseJson)
+        private string BuildAppCastXml(string releaseJson, string releaseNotesHtml)
         {
             var release = JsonNode.Parse(releaseJson)!;
 
@@ -119,8 +158,6 @@ namespace EmoTracker.Services.Updates
                                   out var dt)
                               ? dt.ToString("R")
                               : DateTime.UtcNow.ToString("R");
-            string releaseNotesUrl =
-                $"https://github.com/{_repoOwner}/{_repoName}/releases/tag/{tagName}";
 
             // Only emit the enclosure for the platform we're running on.
             // Omitting sparkle:os means NetSparkle's OS filter won't reject the item —
@@ -161,6 +198,11 @@ namespace EmoTracker.Services.Updates
                 return EmptyAppCast();
             }
 
+            // Inline HTML release notes in a CDATA block so the XML parser ignores the HTML.
+            string descriptionElement = string.IsNullOrWhiteSpace(releaseNotesHtml)
+                ? string.Empty
+                : $"      <description><![CDATA[{releaseNotesHtml}]]></description>";
+
             return $"""
                 <?xml version="1.0" encoding="UTF-8"?>
                 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
@@ -168,8 +210,8 @@ namespace EmoTracker.Services.Updates
                     <title>EmoTracker</title>
                     <item>
                       <title>{EscapeXml(title)}</title>
-                      <sparkle:releaseNotesLink>{releaseNotesUrl}</sparkle:releaseNotesLink>
                       <pubDate>{pubDate}</pubDate>
+                {descriptionElement}
                 {enclosure}
                     </item>
                   </channel>

--- a/EmoTracker/Services/Updates/GitHubAppCastDataDownloader.cs
+++ b/EmoTracker/Services/Updates/GitHubAppCastDataDownloader.cs
@@ -1,0 +1,161 @@
+using NetSparkleUpdater.Interfaces;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Services.Updates
+{
+    /// <summary>
+    /// Implements <see cref="IAppCastDataDownloader"/> by querying the GitHub Releases API
+    /// at runtime and generating a NetSparkle appcast XML string on the fly.  No hosted
+    /// appcast file is required — GitHub Releases is the single source of truth.
+    ///
+    /// Asset filenames are matched to platforms by the naming convention:
+    ///   EmoTracker-{version}-win-x64.zip       → windows
+    ///   EmoTracker-{version}-osx-universal.tar.gz → osx
+    ///   EmoTracker-{version}-linux-x64.tar.xz  → linux
+    /// </summary>
+    public class GitHubAppCastDataDownloader : IAppCastDataDownloader
+    {
+        private const string ApiBase = "https://api.github.com";
+        private readonly string _repoOwner;
+        private readonly string _repoName;
+
+        private static readonly HttpClient Http = new()
+        {
+            DefaultRequestHeaders =
+            {
+                UserAgent = { new ProductInfoHeaderValue("EmoTracker", "1.0") },
+                Accept    = { new MediaTypeWithQualityHeaderValue("application/vnd.github+json") }
+            }
+        };
+
+        // Maps a substring found in the asset filename to a sparkle:os value.
+        private static readonly Dictionary<string, string> PlatformMap = new()
+        {
+            { "win",   "windows" },
+            { "osx",   "osx"     },
+            { "linux", "linux"   },
+        };
+
+        public GitHubAppCastDataDownloader(string repoOwner, string repoName)
+        {
+            _repoOwner = repoOwner;
+            _repoName  = repoName;
+        }
+
+        public string DownloadAndGetAppCastData(string url)
+        {
+            return DownloadAndGetAppCastDataAsync(url).GetAwaiter().GetResult();
+        }
+
+        public async Task<string> DownloadAndGetAppCastDataAsync(string url)
+        {
+            // url is whatever string was passed as the appcast URL to SparkleUpdater;
+            // we ignore it and always talk directly to the GitHub API.
+            try
+            {
+                string apiUrl = $"{ApiBase}/repos/{_repoOwner}/{_repoName}/releases/latest";
+                string json   = await Http.GetStringAsync(apiUrl).ConfigureAwait(false);
+                return BuildAppCastXml(json);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[Update] Failed to fetch latest release from GitHub: {Msg}", ex.Message);
+                return EmptyAppCast();
+            }
+        }
+
+        // Returns the encoding used by the app cast data (UTF-8).
+        public Encoding GetAppCastEncoding() => Encoding.UTF8;
+
+        // -----------------------------------------------------------------------
+
+        private string BuildAppCastXml(string releaseJson)
+        {
+            var release = JsonNode.Parse(releaseJson)!;
+
+            string tagName  = release["tag_name"]!.GetValue<string>();
+            string version  = tagName.TrimStart('v');
+            string title    = release["name"]?.GetValue<string>() ?? $"EmoTracker {version}";
+            string pubDate  = DateTime.TryParse(
+                                  release["published_at"]?.GetValue<string>(),
+                                  out var dt)
+                              ? dt.ToString("R")
+                              : DateTime.UtcNow.ToString("R");
+            string releaseNotesUrl =
+                $"https://github.com/{_repoOwner}/{_repoName}/releases/tag/{tagName}";
+
+            var enclosures = new StringBuilder();
+            var assets = release["assets"]?.AsArray();
+            if (assets != null)
+            {
+                foreach (var asset in assets)
+                {
+                    string assetName = asset!["name"]!.GetValue<string>();
+                    string assetUrl  = asset["browser_download_url"]!.GetValue<string>();
+                    long   size      = asset["size"]?.GetValue<long>() ?? 0;
+
+                    string os = DetectOs(assetName);
+                    if (os == null)
+                        continue;
+
+                    enclosures.AppendLine(
+                        $"""
+                              <enclosure url="{assetUrl}"
+                                         sparkle:version="{version}"
+                                         sparkle:os="{os}"
+                                         length="{size}"
+                                         type="application/octet-stream" />
+                        """);
+                }
+            }
+
+            if (enclosures.Length == 0)
+            {
+                Log.Warning("[Update] No recognised assets found in GitHub release {Tag}.", tagName);
+                return EmptyAppCast();
+            }
+
+            return $"""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+                  <channel>
+                    <title>EmoTracker</title>
+                    <item>
+                      <title>{EscapeXml(title)}</title>
+                      <sparkle:releaseNotesLink>{releaseNotesUrl}</sparkle:releaseNotesLink>
+                      <pubDate>{pubDate}</pubDate>
+                {enclosures}    </item>
+                  </channel>
+                </rss>
+                """;
+        }
+
+        private static string DetectOs(string assetName)
+        {
+            string lower = assetName.ToLowerInvariant();
+            foreach (var kv in PlatformMap)
+                if (lower.Contains(kv.Key))
+                    return kv.Value;
+            return null;
+        }
+
+        private static string EmptyAppCast() =>
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+              <channel><title>EmoTracker</title></channel>
+            </rss>
+            """;
+
+        private static string EscapeXml(string s) =>
+            s.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");
+    }
+}

--- a/EmoTracker/Services/Updates/GitHubAppCastDataDownloader.cs
+++ b/EmoTracker/Services/Updates/GitHubAppCastDataDownloader.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -36,13 +37,20 @@ namespace EmoTracker.Services.Updates
             }
         };
 
-        // Maps a substring found in the asset filename to a sparkle:os value.
+        // Maps a substring found in the asset filename to a platform key.
+        // Order matters: "win" must come before "linux" to avoid false matches.
         private static readonly Dictionary<string, string> PlatformMap = new()
         {
             { "win",   "windows" },
             { "osx",   "osx"     },
             { "linux", "linux"   },
         };
+
+        // Resolved once at startup — the platform key for the currently running OS.
+        private static readonly string CurrentPlatformKey =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows" :
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX)     ? "osx"     :
+                                                                   "linux";
 
         public GitHubAppCastDataDownloader(string repoOwner, string repoName)
         {
@@ -59,11 +67,28 @@ namespace EmoTracker.Services.Updates
         {
             // url is whatever string was passed as the appcast URL to SparkleUpdater;
             // we ignore it and always talk directly to the GitHub API.
+            //
+            // We use /releases?per_page=1 (most-recent-first) rather than
+            // /releases/latest because the latter only returns non-pre-release
+            // entries and would 404 while the project is in pre-release.
             try
             {
-                string apiUrl = $"{ApiBase}/repos/{_repoOwner}/{_repoName}/releases/latest";
+                string apiUrl = $"{ApiBase}/repos/{_repoOwner}/{_repoName}/releases?per_page=1";
                 string json   = await Http.GetStringAsync(apiUrl).ConfigureAwait(false);
-                return BuildAppCastXml(json);
+
+                // The response is a JSON array; unwrap the first element.
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.ValueKind != JsonValueKind.Array ||
+                    doc.RootElement.GetArrayLength() == 0)
+                {
+                    Log.Warning("[Update] No releases found in GitHub API response.");
+                    return EmptyAppCast();
+                }
+
+                string releaseJson = doc.RootElement[0].GetRawText();
+                string appcast = BuildAppCastXml(releaseJson);
+                Log.Debug("[Update] Generated appcast XML:\n{Appcast}", appcast);
+                return appcast;
             }
             catch (Exception ex)
             {
@@ -82,7 +107,12 @@ namespace EmoTracker.Services.Updates
             var release = JsonNode.Parse(releaseJson)!;
 
             string tagName  = release["tag_name"]!.GetValue<string>();
+            // Strip leading 'v' and any pre-release suffix (e.g. "3.0.1.1-preview" → "3.0.1.1")
+            // so that System.Version.TryParse can compare it against the assembly version.
             string version  = tagName.TrimStart('v');
+            int dashIdx = version.IndexOf('-');
+            if (dashIdx >= 0) version = version[..dashIdx];
+            Log.Information("[Update] Release tag: {Tag}, parsed version for appcast: {Version}", tagName, version);
             string title    = release["name"]?.GetValue<string>() ?? $"EmoTracker {version}";
             string pubDate  = DateTime.TryParse(
                                   release["published_at"]?.GetValue<string>(),
@@ -92,7 +122,10 @@ namespace EmoTracker.Services.Updates
             string releaseNotesUrl =
                 $"https://github.com/{_repoOwner}/{_repoName}/releases/tag/{tagName}";
 
-            var enclosures = new StringBuilder();
+            // Only emit the enclosure for the platform we're running on.
+            // Omitting sparkle:os means NetSparkle's OS filter won't reject the item —
+            // we are already doing the OS selection ourselves.
+            string enclosure = null;
             var assets = release["assets"]?.AsArray();
             if (assets != null)
             {
@@ -102,24 +135,29 @@ namespace EmoTracker.Services.Updates
                     string assetUrl  = asset["browser_download_url"]!.GetValue<string>();
                     long   size      = asset["size"]?.GetValue<long>() ?? 0;
 
-                    string os = DetectOs(assetName);
-                    if (os == null)
+                    string platformKey = DetectPlatformKey(assetName);
+                    if (platformKey != CurrentPlatformKey)
                         continue;
 
-                    enclosures.AppendLine(
+                    // sparkle:os must be present — omitting it defaults to "windows",
+                    // which causes NetSparkle to filter the item out on macOS/Linux.
+                    // Use the same key we matched on so the value is always consistent.
+                    enclosure =
                         $"""
                               <enclosure url="{assetUrl}"
                                          sparkle:version="{version}"
-                                         sparkle:os="{os}"
+                                         sparkle:os="{platformKey}"
                                          length="{size}"
                                          type="application/octet-stream" />
-                        """);
+                        """;
+                    break; // first match wins
                 }
             }
 
-            if (enclosures.Length == 0)
+            if (enclosure == null)
             {
-                Log.Warning("[Update] No recognised assets found in GitHub release {Tag}.", tagName);
+                Log.Warning("[Update] No asset found for current platform ({Platform}) in GitHub release {Tag}.",
+                    CurrentPlatformKey, tagName);
                 return EmptyAppCast();
             }
 
@@ -132,13 +170,14 @@ namespace EmoTracker.Services.Updates
                       <title>{EscapeXml(title)}</title>
                       <sparkle:releaseNotesLink>{releaseNotesUrl}</sparkle:releaseNotesLink>
                       <pubDate>{pubDate}</pubDate>
-                {enclosures}    </item>
+                {enclosure}
+                    </item>
                   </channel>
                 </rss>
                 """;
         }
 
-        private static string DetectOs(string assetName)
+        private static string DetectPlatformKey(string assetName)
         {
             string lower = assetName.ToLowerInvariant();
             foreach (var kv in PlatformMap)

--- a/EmoTracker/Services/Updates/GitHubAppCastDataDownloader.cs
+++ b/EmoTracker/Services/Updates/GitHubAppCastDataDownloader.cs
@@ -1,10 +1,10 @@
+using Markdig;
 using NetSparkleUpdater.Interfaces;
 using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
@@ -86,16 +86,9 @@ namespace EmoTracker.Services.Updates
                     return EmptyAppCast();
                 }
 
-                var releaseElement = doc.RootElement[0];
-                string releaseJson = releaseElement.GetRawText();
+                string releaseJson = doc.RootElement[0].GetRawText();
 
-                // Render the release body markdown to HTML via the GitHub Markdown API.
-                string bodyMarkdown = releaseElement.TryGetProperty("body", out var bodyProp)
-                    ? bodyProp.GetString() ?? string.Empty
-                    : string.Empty;
-                string releaseNotesHtml = await RenderMarkdownAsync(bodyMarkdown).ConfigureAwait(false);
-
-                string appcast = BuildAppCastXml(releaseJson, releaseNotesHtml);
+                string appcast = BuildAppCastXml(releaseJson);
                 Log.Debug("[Update] Generated appcast XML:\n{Appcast}", appcast);
                 return appcast;
             }
@@ -106,42 +99,12 @@ namespace EmoTracker.Services.Updates
             }
         }
 
-        /// <summary>
-        /// Calls the GitHub Markdown API to render <paramref name="markdown"/> as HTML.
-        /// Falls back to a plain-text preformatted block on any error.
-        /// </summary>
-        private async Task<string> RenderMarkdownAsync(string markdown)
-        {
-            if (string.IsNullOrWhiteSpace(markdown))
-                return string.Empty;
-            try
-            {
-                // Use GFM mode with the repo context so issue/PR references resolve.
-                var payload = new
-                {
-                    text    = markdown,
-                    mode    = "gfm",
-                    context = $"{_repoOwner}/{_repoName}"
-                };
-                using var response = await Http
-                    .PostAsJsonAsync($"{ApiBase}/markdown", payload)
-                    .ConfigureAwait(false);
-                response.EnsureSuccessStatusCode();
-                return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                Log.Warning(ex, "[Update] Failed to render release notes markdown; falling back to plain text.");
-                return $"<pre>{EscapeXml(markdown)}</pre>";
-            }
-        }
-
         // Returns the encoding used by the app cast data (UTF-8).
         public Encoding GetAppCastEncoding() => Encoding.UTF8;
 
         // -----------------------------------------------------------------------
 
-        private string BuildAppCastXml(string releaseJson, string releaseNotesHtml)
+        private string BuildAppCastXml(string releaseJson)
         {
             var release = JsonNode.Parse(releaseJson)!;
 
@@ -198,10 +161,12 @@ namespace EmoTracker.Services.Updates
                 return EmptyAppCast();
             }
 
-            // Inline HTML release notes in a CDATA block so the XML parser ignores the HTML.
-            string descriptionElement = string.IsNullOrWhiteSpace(releaseNotesHtml)
+            // Convert markdown release notes to HTML using Markdig.
+            // HtmlLabel (Avalonia.HtmlRenderer) renders the HTML in the update dialog.
+            string bodyMarkdown = release["body"]?.GetValue<string>() ?? string.Empty;
+            string descriptionElement = string.IsNullOrWhiteSpace(bodyMarkdown)
                 ? string.Empty
-                : $"      <description><![CDATA[{releaseNotesHtml}]]></description>";
+                : $"      <description><![CDATA[{MarkdownToHtml(bodyMarkdown)}]]></description>";
 
             return $"""
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -218,6 +183,12 @@ namespace EmoTracker.Services.Updates
                 </rss>
                 """;
         }
+
+        private static readonly MarkdownPipeline MarkdigPipeline =
+            new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+
+        private static string MarkdownToHtml(string markdown) =>
+            Markdig.Markdown.ToHtml(markdown, MarkdigPipeline);
 
         private static string DetectPlatformKey(string assetName)
         {

--- a/EmoTracker/Services/Updates/UpdateService.cs
+++ b/EmoTracker/Services/Updates/UpdateService.cs
@@ -1,0 +1,110 @@
+using EmoTracker.Data;
+using NetSparkleUpdater;
+using NetSparkleUpdater.Enums;
+using NetSparkleUpdater.SignatureVerifiers;
+using NetSparkleUpdater.UI.Avalonia;
+using Serilog;
+using System;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Services.Updates
+{
+    /// <summary>
+    /// A <see cref="SparkleUpdater"/> subclass that overrides
+    /// <see cref="RunDownloadedInstaller"/> to use the cross-platform
+    /// zip/tar extraction and swap-script strategy.
+    /// </summary>
+    internal class EmoTrackerSparkleUpdater : SparkleUpdater
+    {
+        public EmoTrackerSparkleUpdater(string appcastUrl, Ed25519Checker signatureVerifier)
+            : base(appcastUrl, signatureVerifier)
+        {
+        }
+
+        protected override async Task RunDownloadedInstaller(string downloadFilePath)
+        {
+            await ZipInstallAndRelaunch.RunDownloadedInstallerAsync(downloadFilePath);
+        }
+    }
+
+    /// <summary>
+    /// Owns and configures the <see cref="SparkleUpdater"/> instance and exposes a
+    /// simple API for the rest of the app to trigger update checks.
+    ///
+    /// The appcast URL is a placeholder — <see cref="GitHubAppCastDataDownloader"/>
+    /// ignores it and talks directly to the GitHub Releases API.
+    /// </summary>
+    public class UpdateService : IDisposable
+    {
+        private const string RepoOwner   = "EmoTracker-Community";
+        private const string RepoName    = "EmoTracker";
+        private const string AppCastUrl  = $"https://github.com/{RepoOwner}/{RepoName}";
+
+        private readonly EmoTrackerSparkleUpdater _sparkle;
+        private bool _disposed;
+
+        public static UpdateService Instance { get; } = new();
+
+        private UpdateService()
+        {
+            // Signature verification is disabled initially (Unsafe mode).
+            // Enable once Ed25519 keys are configured in the release workflow.
+            var signatureVerifier = new Ed25519Checker(SecurityMode.Unsafe, null);
+
+            _sparkle = new EmoTrackerSparkleUpdater(AppCastUrl, signatureVerifier)
+            {
+                UIFactory               = new UIFactory(null),
+                // Inject our GitHub-backed appcast downloader.
+                AppCastDataDownloader   = new GitHubAppCastDataDownloader(RepoOwner, RepoName),
+                RelaunchAfterUpdate     = true,
+            };
+
+            _sparkle.UpdateDetected           += (_, info) =>
+                Log.Information("[Update] Update available: {Version}", info.LatestVersion);
+            _sparkle.UpdateCheckFinished      += (_, status) =>
+                Log.Debug("[Update] Update check finished. Status: {Status}", status);
+            _sparkle.DownloadStarted          += (_, _) =>
+                Log.Information("[Update] Download started.");
+            _sparkle.DownloadFinished         += (_, _) =>
+                Log.Information("[Update] Download finished.");
+            _sparkle.DownloadHadError         += (item, path, ex) =>
+                Log.Warning("[Update] Download error for {Item}: {Err}", item?.DownloadLink, ex?.Message);
+        }
+
+        /// <summary>
+        /// Runs a silent background update check on startup.  Shows the update
+        /// dialog only if a new version is found and the user has not previously
+        /// skipped it.
+        /// </summary>
+        public void StartBackgroundCheck()
+        {
+            if (!ApplicationSettings.Instance.EnableAutoUpdateCheck)
+            {
+                Log.Debug("[Update] Auto update check disabled by user setting.");
+                return;
+            }
+
+            Log.Debug("[Update] Starting background update check.");
+            _sparkle.StartLoop(doInitialCheck: true, forceInitialCheck: false,
+                checkFrequency: TimeSpan.FromHours(24));
+        }
+
+        /// <summary>
+        /// Performs an immediate check and shows the update window regardless of
+        /// whether the user has previously skipped the version.  For use from
+        /// the "Check for Updates" menu item.
+        /// </summary>
+        public async Task CheckAndShowUpdateWindowAsync()
+        {
+            Log.Information("[Update] Manual update check triggered.");
+            await _sparkle.CheckForUpdatesAtUserRequest();
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _sparkle.Dispose();
+        }
+    }
+}

--- a/EmoTracker/Services/Updates/UpdateService.cs
+++ b/EmoTracker/Services/Updates/UpdateService.cs
@@ -2,7 +2,6 @@ using EmoTracker.Data;
 using NetSparkleUpdater;
 using NetSparkleUpdater.Enums;
 using NetSparkleUpdater.SignatureVerifiers;
-using NetSparkleUpdater.UI.Avalonia;
 using Serilog;
 using System;
 using System.Threading.Tasks;
@@ -36,9 +35,9 @@ namespace EmoTracker.Services.Updates
     /// </summary>
     public class UpdateService : IDisposable
     {
-        private const string RepoOwner   = "EmoTracker-Community";
-        private const string RepoName    = "EmoTracker";
-        private const string AppCastUrl  = $"https://github.com/{RepoOwner}/{RepoName}";
+        private const string RepoOwner  = "EmoTracker-Community";
+        private const string RepoName   = "EmoTracker";
+        private const string AppCastUrl = $"https://github.com/{RepoOwner}/{RepoName}";
 
         private readonly EmoTrackerSparkleUpdater _sparkle;
         private bool _disposed;
@@ -51,27 +50,30 @@ namespace EmoTracker.Services.Updates
             // Enable once Ed25519 keys are configured in the release workflow.
             var signatureVerifier = new Ed25519Checker(SecurityMode.Unsafe, null);
 
+            var uiFactory = new EmoTrackerUIFactory();
+
             _sparkle = new EmoTrackerSparkleUpdater(AppCastUrl, signatureVerifier)
             {
-                UIFactory               = new UIFactory(null),
-                // Inject our GitHub-backed appcast downloader.
-                AppCastDataDownloader   = new GitHubAppCastDataDownloader(RepoOwner, RepoName),
-                RelaunchAfterUpdate     = true,
+                UIFactory             = uiFactory,
+                AppCastDataDownloader = new GitHubAppCastDataDownloader(RepoOwner, RepoName),
+                RelaunchAfterUpdate   = true,
             };
 
             Log.Debug("[Update] AppCastUrl: {Url}", _sparkle.AppCastUrl);
 
-            _sparkle.UpdateDetected           += (_, info) =>
+            _sparkle.UpdateDetected      += (_, info) =>
                 Log.Information("[Update] Update available: {Version}", info.LatestVersion);
-            _sparkle.UpdateCheckFinished      += (_, status) =>
+            _sparkle.UpdateCheckFinished += (_, status) =>
                 Log.Debug("[Update] Update check finished. Status: {Status}", status);
-            _sparkle.DownloadStarted          += (_, _) =>
+            _sparkle.DownloadStarted     += (_, _) =>
                 Log.Information("[Update] Download started.");
-            _sparkle.DownloadFinished         += (_, _) =>
+            _sparkle.DownloadFinished    += (_, _) =>
                 Log.Information("[Update] Download finished.");
-            _sparkle.DownloadHadError         += (item, path, ex) =>
+            _sparkle.DownloadHadError    += (item, path, ex) =>
                 Log.Warning("[Update] Download error for {Item}: {Err}", item?.DownloadLink, ex?.Message);
         }
+
+        // ── Public API ─────────────────────────────────────────────────────────
 
         /// <summary>
         /// Runs a silent background update check on startup.  Shows the update

--- a/EmoTracker/Services/Updates/UpdateService.cs
+++ b/EmoTracker/Services/Updates/UpdateService.cs
@@ -59,6 +59,8 @@ namespace EmoTracker.Services.Updates
                 RelaunchAfterUpdate     = true,
             };
 
+            Log.Debug("[Update] AppCastUrl: {Url}", _sparkle.AppCastUrl);
+
             _sparkle.UpdateDetected           += (_, info) =>
                 Log.Information("[Update] Update available: {Version}", info.LatestVersion);
             _sparkle.UpdateCheckFinished      += (_, status) =>

--- a/EmoTracker/Services/Updates/ZipInstallAndRelaunch.cs
+++ b/EmoTracker/Services/Updates/ZipInstallAndRelaunch.cs
@@ -1,0 +1,180 @@
+using Serilog;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Services.Updates
+{
+    /// <summary>
+    /// Handles the apply-and-relaunch step for zip/tar archive update packages.
+    ///
+    /// Strategy (all platforms):
+    ///   1. Extract the downloaded archive into a .staging directory next to the
+    ///      current install directory.
+    ///   2. Write a platform-specific swap script that waits for this process to
+    ///      exit, copies the staging files over the install directory, deletes
+    ///      staging, and relaunches EmoTracker.
+    ///   3. Launch the script detached and call Environment.Exit(0).
+    ///
+    /// Windows: a .bat file that polls tasklist until our PID disappears, then
+    ///          uses xcopy to overwrite the install directory in-place.
+    /// macOS / Linux: a .sh file; no file-locking concern so a brief sleep suffices.
+    /// </summary>
+    public static class ZipInstallAndRelaunch
+    {
+        public static async Task RunDownloadedInstallerAsync(string downloadFilePath)
+        {
+            try
+            {
+                string installDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+                string stagingDir = Path.Combine(installDir, ".update-staging");
+
+                Log.Information("[Update] Extracting update archive to staging dir: {Dir}", stagingDir);
+
+                if (Directory.Exists(stagingDir))
+                    Directory.Delete(stagingDir, recursive: true);
+                Directory.CreateDirectory(stagingDir);
+
+                await ExtractArchiveAsync(downloadFilePath, stagingDir, CancellationToken.None);
+
+                string exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "EmoTracker.exe" : "EmoTracker";
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    LaunchWindowsSwapScript(installDir, stagingDir, exeName);
+                else
+                    LaunchUnixSwapScript(installDir, stagingDir, exeName);
+
+                Log.Information("[Update] Swap script launched — exiting for update.");
+                Environment.Exit(0);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "[Update] Failed to apply update: {Msg}", ex.Message);
+                throw;
+            }
+        }
+
+        // -----------------------------------------------------------------------
+        // Archive extraction
+        // -----------------------------------------------------------------------
+
+        private static async Task ExtractArchiveAsync(
+            string archivePath, string destDir, CancellationToken ct)
+        {
+            string lower = archivePath.ToLowerInvariant();
+
+            if (lower.EndsWith(".zip"))
+            {
+                await Task.Run(() => ZipFile.ExtractToDirectory(archivePath, destDir, overwriteFiles: true), ct);
+            }
+            else if (lower.EndsWith(".tar.gz") || lower.EndsWith(".tar.xz") || lower.EndsWith(".tgz"))
+            {
+                // Use the system tar — available on macOS, Linux, and Windows 10+.
+                await RunProcessAsync("tar", $"xf \"{archivePath}\" -C \"{destDir}\"", ct);
+            }
+            else
+            {
+                throw new NotSupportedException($"Unsupported archive format: {Path.GetFileName(archivePath)}");
+            }
+        }
+
+        private static async Task RunProcessAsync(string exe, string arguments, CancellationToken ct)
+        {
+            var psi = new ProcessStartInfo(exe, arguments)
+            {
+                UseShellExecute        = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError  = true,
+                CreateNoWindow         = true,
+            };
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException($"Failed to start {exe}");
+
+            await proc.WaitForExitAsync(ct);
+
+            if (proc.ExitCode != 0)
+            {
+                string err = await proc.StandardError.ReadToEndAsync(ct);
+                throw new InvalidOperationException(
+                    $"{exe} exited with code {proc.ExitCode}: {err}");
+            }
+        }
+
+        // -----------------------------------------------------------------------
+        // Windows batch swap script
+        // -----------------------------------------------------------------------
+
+        private static void LaunchWindowsSwapScript(
+            string installDir, string stagingDir, string exeName)
+        {
+            int pid = Environment.ProcessId;
+
+            string script = $"""
+                @echo off
+                setlocal
+
+                set INSTALL_DIR={installDir}
+                set STAGING_DIR={stagingDir}
+                set EXE_PATH={Path.Combine(installDir, exeName)}
+                set PID={pid}
+
+                :wait_loop
+                tasklist /fi "pid eq %PID%" 2>nul | find "%PID%" >nul
+                if %errorlevel%==0 (
+                    timeout /t 1 /nobreak >nul
+                    goto wait_loop
+                )
+
+                xcopy /Y /E /I /Q "%STAGING_DIR%\*" "%INSTALL_DIR%\"
+                rmdir /S /Q "%STAGING_DIR%"
+                start "" "%EXE_PATH%"
+                """;
+
+            string scriptPath = Path.Combine(Path.GetTempPath(), "EmoTracker_update.bat");
+            File.WriteAllText(scriptPath, script);
+
+            Process.Start(new ProcessStartInfo("cmd.exe", $"/c \"{scriptPath}\"")
+            {
+                UseShellExecute  = true,
+                CreateNoWindow   = true,
+                WindowStyle      = ProcessWindowStyle.Hidden,
+            });
+        }
+
+        // -----------------------------------------------------------------------
+        // macOS / Linux shell swap script
+        // -----------------------------------------------------------------------
+
+        private static void LaunchUnixSwapScript(
+            string installDir, string stagingDir, string exeName)
+        {
+            string exePath = Path.Combine(installDir, exeName);
+
+            string script = $"""
+                #!/bin/sh
+                sleep 1
+                cp -R "{stagingDir}/." "{installDir}/"
+                rm -rf "{stagingDir}"
+                chmod +x "{exePath}"
+                "{exePath}" &
+                """;
+
+            string scriptPath = Path.Combine(Path.GetTempPath(), "emotracker_update.sh");
+            File.WriteAllText(scriptPath, script);
+
+            // Make executable
+            RunProcessAsync("chmod", $"+x \"{scriptPath}\"", CancellationToken.None).GetAwaiter().GetResult();
+
+            Process.Start(new ProcessStartInfo("/bin/sh", $"\"{scriptPath}\"")
+            {
+                UseShellExecute = true,
+            });
+        }
+    }
+}

--- a/EmoTracker/UI/EmoCheckingForUpdatesWindow.axaml
+++ b/EmoTracker/UI/EmoCheckingForUpdatesWindow.axaml
@@ -1,0 +1,37 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="EmoTracker.UI.EmoCheckingForUpdatesWindow"
+        Title="Software Update"
+        Width="340" Height="130"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner"
+        Background="#212121"
+        SystemDecorations="BorderOnly">
+
+    <Grid RowDefinitions="*,Auto" Margin="24,20,24,16">
+
+        <StackPanel Grid.Row="0" VerticalAlignment="Center" Spacing="12">
+            <TextBlock Text="Checking for updates…"
+                       Foreground="WhiteSmoke"
+                       FontSize="14"
+                       HorizontalAlignment="Center"/>
+            <ProgressBar IsIndeterminate="True"
+                         Height="4"
+                         Foreground="#35e0b5"
+                         Background="#333339"
+                         CornerRadius="2"/>
+        </StackPanel>
+
+        <Button Grid.Row="1"
+                Content="Cancel"
+                x:Name="CancelButton"
+                HorizontalAlignment="Right"
+                Padding="14,6"
+                CornerRadius="6"
+                Background="#333339"
+                Foreground="WhiteSmoke"
+                BorderThickness="1"
+                BorderBrush="#444444"
+                Click="CancelButton_Click"/>
+    </Grid>
+</Window>

--- a/EmoTracker/UI/EmoCheckingForUpdatesWindow.axaml.cs
+++ b/EmoTracker/UI/EmoCheckingForUpdatesWindow.axaml.cs
@@ -1,0 +1,33 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using NetSparkleUpdater.Interfaces;
+using System;
+
+namespace EmoTracker.UI
+{
+    public partial class EmoCheckingForUpdatesWindow : Window, ICheckingForUpdates
+    {
+        public event EventHandler UpdatesUIClosing;
+
+        public EmoCheckingForUpdatesWindow()
+        {
+            InitializeComponent();
+        }
+
+        public new void Show()
+        {
+            base.Show();
+        }
+
+        public new void Close()
+        {
+            UpdatesUIClosing?.Invoke(this, EventArgs.Empty);
+            base.Close();
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/EmoTracker/UI/EmoUpdateAvailableWindow.axaml
+++ b/EmoTracker/UI/EmoUpdateAvailableWindow.axaml
@@ -1,0 +1,95 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:html="clr-namespace:TheArtOfDev.HtmlRenderer.Avalonia;assembly=Avalonia.HtmlRenderer"
+        x:Class="EmoTracker.UI.EmoUpdateAvailableWindow"
+        Title="Software Update"
+        Width="680" Height="520"
+        MinWidth="480" MinHeight="340"
+        WindowStartupLocation="CenterOwner"
+        Background="#212121">
+
+    <Window.Styles>
+        <Style Selector="Button.action">
+            <Setter Property="Background" Value="#333339"/>
+            <Setter Property="Foreground" Value="WhiteSmoke"/>
+            <Setter Property="BorderBrush" Value="#444444"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="Padding" Value="16,7"/>
+            <Setter Property="MinWidth" Value="120"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.action:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#3a3a42"/>
+        </Style>
+        <Style Selector="Button.primary">
+            <Setter Property="Background" Value="#35e0b5"/>
+            <Setter Property="Foreground" Value="#111111"/>
+            <Setter Property="BorderBrush" Value="#35e0b5"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="Padding" Value="16,7"/>
+            <Setter Property="MinWidth" Value="140"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.primary:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#28c49e"/>
+        </Style>
+        <Style Selector="Button.primary:pressed /template/ ContentPresenter">
+            <Setter Property="Background" Value="#1ea882"/>
+        </Style>
+    </Window.Styles>
+
+    <Grid RowDefinitions="Auto,*,Auto">
+
+        <!-- Header -->
+        <Border Grid.Row="0" Background="#252030" Padding="20,16,20,16">
+            <StackPanel Spacing="4">
+                <TextBlock x:Name="TitleText"
+                           Text="A new version of EmoTracker is available."
+                           Foreground="WhiteSmoke"
+                           FontSize="15"
+                           FontWeight="SemiBold"/>
+                <TextBlock x:Name="SubtitleText"
+                           Foreground="#888888"
+                           FontSize="12"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Release notes -->
+        <Border Grid.Row="1" Background="#1a1a1a" Padding="14,12">
+            <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                          VerticalScrollBarVisibility="Auto">
+                <Grid>
+                    <html:HtmlLabel x:Name="ReleaseNotesLabel"
+                                    Text=""
+                                    Background="#1a1a1a"
+                                    AutoSizeHeightOnly="True"/>
+                </Grid>
+            </ScrollViewer>
+        </Border>
+
+        <!-- Footer -->
+        <Border Grid.Row="2" Background="#252030" Padding="16,12">
+            <Grid ColumnDefinitions="Auto,*,Auto,8,Auto">
+                <Button x:Name="SkipButton"
+                        Grid.Column="0"
+                        Classes="action"
+                        Content="Skip this version"
+                        Click="SkipButton_Click"/>
+                <Button x:Name="RemindButton"
+                        Grid.Column="2"
+                        Classes="action"
+                        Content="Remind me later"
+                        Click="RemindButton_Click"/>
+                <Button x:Name="DownloadButton"
+                        Grid.Column="4"
+                        Classes="primary"
+                        Content="Download &amp; Install"
+                        Click="DownloadButton_Click"/>
+            </Grid>
+        </Border>
+
+    </Grid>
+</Window>

--- a/EmoTracker/UI/EmoUpdateAvailableWindow.axaml.cs
+++ b/EmoTracker/UI/EmoUpdateAvailableWindow.axaml.cs
@@ -1,0 +1,117 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using NetSparkleUpdater;
+using NetSparkleUpdater.Enums;
+using NetSparkleUpdater.Events;
+using NetSparkleUpdater.Interfaces;
+using NetSparkleUpdater.UI.Avalonia.Interfaces;
+using System.Collections.Generic;
+
+namespace EmoTracker.UI
+{
+    public partial class EmoUpdateAvailableWindow : Window, IUpdateAvailable, IReleaseNotesDisplayer
+    {
+        // ── IUpdateAvailable ───────────────────────────────────────────────────
+        public event UserRespondedToUpdate UserResponded;
+
+        public UpdateAvailableResult Result { get; private set; } = UpdateAvailableResult.None;
+
+        public AppCastItem CurrentItem { get; set; }
+
+        // ── Construction ───────────────────────────────────────────────────────
+        public EmoUpdateAvailableWindow()
+        {
+            InitializeComponent();
+        }
+
+        public EmoUpdateAvailableWindow(List<AppCastItem> updates, string currentVersion, string appName)
+            : this()
+        {
+            if (updates == null || updates.Count == 0) return;
+
+            CurrentItem = updates[0];
+            string newVersion = CurrentItem.Version ?? string.Empty;
+
+            TitleText.Text    = $"A new version of {appName} is available.";
+            SubtitleText.Text = $"{appName} {newVersion} is now available — you have {currentVersion}. Would you like to download it now?";
+
+            // Populate release notes from the appcast Description field.
+            // GitHubAppCastDataDownloader converts markdown → HTML via Markdig;
+            // we wrap it in a CSS stylesheet and hand it to HtmlLabel.
+            string html = CurrentItem.Description ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(html))
+                ReleaseNotesLabel.Text = WrapWithCss(html);
+        }
+
+        // ── IReleaseNotesDisplayer ─────────────────────────────────────────────
+        // NetSparkle calls this if it manages to go through its own ReleaseNotesGrabber
+        // pipeline; we ignore it since we populate notes directly in the constructor.
+        public void ShowReleaseNotes(string html) { }
+
+        // ── IUpdateAvailable ───────────────────────────────────────────────────
+        public new void Show()
+        {
+            base.Show();
+        }
+
+        public void HideReleaseNotes()
+        {
+            if (ReleaseNotesLabel?.Parent is Grid g && g.Parent is ScrollViewer sv && sv.Parent is Border b)
+                b.IsVisible = false;
+        }
+
+        private static string WrapWithCss(string htmlBody) =>
+            "<html><head><style>" +
+            "body { background-color: #1a1a1a; color: #c8c8c8; font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 13px; line-height: 1.65; margin: 12px 8px; word-wrap: break-word; overflow-wrap: break-word; }" +
+            "h1 { color: #f0f0f0; font-size: 17px; font-weight: 600; margin: 0 0 14px 0; padding-bottom: 8px; border-bottom: 1px solid #333339; }" +
+            "h2 { color: #f0f0f0; font-size: 15px; font-weight: 600; margin: 20px 0 10px 0; padding-bottom: 6px; border-bottom: 1px solid #2a2a2a; }" +
+            "h3, h4 { color: #e0e0e0; font-size: 13px; font-weight: 600; margin: 16px 0 8px 0; }" +
+            "h1:first-child, h2:first-child, h3:first-child, h4:first-child { margin-top: 0; }" +
+            "a { color: #7eb5d6; word-break: break-all; }" +
+            "p { margin: 0 0 10px 0; }" +
+            "code { background-color: #2d2d2d; color: #e0e0e0; padding: 1px 5px; border-radius: 3px; font-size: 12px; }" +
+            "pre { background-color: #111111; padding: 10px 12px; border-radius: 4px; border-left: 3px solid #555560; overflow: hidden; margin: 10px 0 14px 0; }" +
+            "pre code { background-color: transparent; padding: 0; }" +
+            "ul { margin: 0 0 10px 0; padding-left: 20px; list-style-type: disc; }" +
+            "ol { margin: 0 0 10px 0; padding-left: 20px; }" +
+            "li { margin-bottom: 5px; }" +
+            "hr { border: none; border-top: 1px solid #2e2e2e; margin: 18px 0; }" +
+            "strong { color: #e8e8e8; }" +
+            "blockquote { border-left: 3px solid #444444; margin: 10px 0; padding: 4px 12px; color: #909090; }" +
+            "</style></head><body>" +
+            htmlBody +
+            "</body></html>";
+
+        public void HideRemindMeLaterButton()  => RemindButton.IsVisible   = false;
+        public void HideSkipButton()           => SkipButton.IsVisible     = false;
+
+        public void BringToFront()
+        {
+            Activate();
+            Topmost = true;
+            Topmost = false;
+        }
+
+        public new void Close()
+        {
+            base.Close();
+        }
+
+        // ── Button handlers ────────────────────────────────────────────────────
+        private void SkipButton_Click(object sender, RoutedEventArgs e)
+            => Respond(UpdateAvailableResult.SkipUpdate);
+
+        private void RemindButton_Click(object sender, RoutedEventArgs e)
+            => Respond(UpdateAvailableResult.RemindMeLater);
+
+        private void DownloadButton_Click(object sender, RoutedEventArgs e)
+            => Respond(UpdateAvailableResult.InstallUpdate);
+
+        private void Respond(UpdateAvailableResult result)
+        {
+            Result = result;
+            UserResponded?.Invoke(this, new UpdateResponseEventArgs(result, CurrentItem));
+            base.Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Integrates **NetSparkleUpdater 3.0.4** for cross-platform auto-update support, using GitHub Releases as the update source — no hosted appcast file required
- Implements a custom `GitHubAppCastDataDownloader` that queries the GitHub API at runtime and generates appcast XML on the fly, with three key correctness fixes:
  - Uses `/releases?per_page=1` instead of `/releases/latest` (which 404s on pre-release-only repos)
  - Strips pre-release suffixes from tag versions (e.g. `3.0.1.1-preview` → `3.0.1.1`) so `System.Version` can parse and compare them
  - Emits a single per-platform `<enclosure>` with the correct `sparkle:os` attribute to pass NetSparkle's OS filter
- Implements fully custom **"Checking for Updates"** and **"Update Available"** dialog windows (`EmoCheckingForUpdatesWindow`, `EmoUpdateAvailableWindow`) styled to match EmoTracker's dark theme, wired up via `EmoTrackerUIFactory`
- Uses **Markdig** to render GitHub release notes markdown → HTML locally (no GitHub Markdown API call), displayed via `Avalonia.HtmlRenderer`'s `HtmlLabel` with a themed CSS stylesheet

## Test plan

- [ ] Launch app and trigger update check from the menu
- [ ] "Checking for Updates" progress dialog appears with correct dark styling
- [ ] "Update Available" dialog appears showing correct version numbers in the header
- [ ] Release notes render correctly (headings, bullet lists, inline code, links)
- [ ] Release notes do not clip horizontally and scroll vertically if long
- [ ] Skip / Remind Me Later / Download & Install buttons respond correctly
- [ ] With current assembly version, no update dialog appears (up-to-date path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)