### PR TITLE
Fix crash: collection modified during enumeration in PackageRepository

### DIFF
--- a/EmoTracker.Data/Packages/PackageRepository.cs
+++ b/EmoTracker.Data/Packages/PackageRepository.cs
@@ -568,8 +568,6 @@ namespace EmoTracker.Data.Packages
                                             !string.IsNullOrWhiteSpace(instance.URL))
                                         {
                                             mPackages.Add(instance);
-                                            PackageManager.Instance.ForceRefreshProperty("UpdatesAvailable");
-                                            PackageManager.Instance.ForceRefreshProperty("CurrentPackageHasUpdateAvailable");
                                         }
                                     }
                                 }
@@ -579,6 +577,8 @@ namespace EmoTracker.Data.Packages
                 }
 
                 DownloadStatus = DownloadStatus.Complete;
+                PackageManager.Instance.ForceRefreshProperty("UpdatesAvailable");
+                PackageManager.Instance.ForceRefreshProperty("CurrentPackageHasUpdateAvailable");
             }
             catch
             {


### PR DESCRIPTION
## Summary
- `ForceRefreshProperty` was called inside the `mPackages.Add` loop in `MWebClient_DownloadDataCompleted`, triggering `CurrentPackageHasUpdateAvailable` to enumerate `repository.Packages` while new entries were still being added to it
- Moved both `ForceRefreshProperty` calls to after the loop completes (once all packages are populated), just before `DownloadStatus = Complete`

## Test plan
- [ ] Launch EmoTracker and leave running for 30+ minutes with a package loaded
- [ ] Verify no `InvalidOperationException: Collection was modified` crash occurs
- [ ] Verify update-available indicators still appear correctly after repository refresh

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)