### PR TITLE
Fix infinite NDI log spam for null/unsupported snapshot pixel format

### DIFF
--- a/EmoTracker/Extensions/NDI/NdiSendContainer.cs
+++ b/EmoTracker/Extensions/NDI/NdiSendContainer.cs
@@ -326,14 +326,14 @@ namespace EmoTracker.Extensions.NDI
                 _attached, NdiEnabled, _ndiInitialized, NdiName);
         }
 
-        // Throttle for unsupported pixel format warnings.
-        private DateTime _lastFormatWarningLogUtc = DateTime.MinValue;
+        // Log unsupported pixel format once per application run so the user sees
+        // it exactly once without flooding the log on every capture tick.
+        private bool _formatWarningLogged = false;
         private void LogUnsupportedFormatWarning(Avalonia.Platform.PixelFormat? format)
         {
-            DateTime now = DateTime.UtcNow;
-            if ((now - _lastFormatWarningLogUtc).TotalSeconds < 5) return;
-            _lastFormatWarningLogUtc = now;
-            Log.Warning("[NDI] Unsupported snapshot pixel format {Format}; defaulting to BGRA.", format);
+            if (_formatWarningLogged) return;
+            _formatWarningLogged = true;
+            Log.Warning("[NDI] Unsupported snapshot pixel format {Format}; defaulting to platform default.", format);
         }
 
         // Throttled debug heartbeat showing that captures are being produced.
@@ -450,11 +450,14 @@ namespace EmoTracker.Extensions.NDI
                 // than inferring it from the OS.  The compositor backend decides channel
                 // order (BGRA on Windows/D3D, RGBA on macOS/Metal), and reading it here
                 // handles any future backend changes automatically.
+                // Derive NDI pixel format from the snapshot's reported format.
                 // A null format means the compositor returned an unusable snapshot
-                // (e.g. the visual tree isn't ready yet).  Skip the frame silently
-                // rather than trying to send garbage pixels.
-                if (snapshot.Format == null)
-                    return;
+                // (e.g. the visual tree isn't ready yet); fall back to the platform
+                // default rather than dropping the frame.
+                // macOS/Metal uses RGBA, Windows/D3D and Linux use BGRA.
+                NDIlib.FourCC_type_e platformDefault = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                    ? NDIlib.FourCC_type_e.FourCC_type_RGBA
+                    : NDIlib.FourCC_type_e.FourCC_type_BGRA;
 
                 NDIlib.FourCC_type_e ndiFormat;
                 switch (snapshot.Format)
@@ -467,7 +470,7 @@ namespace EmoTracker.Extensions.NDI
                         break;
                     default:
                         LogUnsupportedFormatWarning(snapshot.Format);
-                        ndiFormat = NDIlib.FourCC_type_e.FourCC_type_BGRA;
+                        ndiFormat = platformDefault;
                         break;
                 }
 

--- a/EmoTracker/Extensions/NDI/NdiSendContainer.cs
+++ b/EmoTracker/Extensions/NDI/NdiSendContainer.cs
@@ -326,6 +326,16 @@ namespace EmoTracker.Extensions.NDI
                 _attached, NdiEnabled, _ndiInitialized, NdiName);
         }
 
+        // Throttle for unsupported pixel format warnings.
+        private DateTime _lastFormatWarningLogUtc = DateTime.MinValue;
+        private void LogUnsupportedFormatWarning(Avalonia.Platform.PixelFormat? format)
+        {
+            DateTime now = DateTime.UtcNow;
+            if ((now - _lastFormatWarningLogUtc).TotalSeconds < 5) return;
+            _lastFormatWarningLogUtc = now;
+            Log.Warning("[NDI] Unsupported snapshot pixel format {Format}; defaulting to BGRA.", format);
+        }
+
         // Throttled debug heartbeat showing that captures are being produced.
         // One line every ~5s keeps the log readable while still confirming flow.
         private DateTime _lastCaptureHeartbeatUtc = DateTime.MinValue;
@@ -440,6 +450,12 @@ namespace EmoTracker.Extensions.NDI
                 // than inferring it from the OS.  The compositor backend decides channel
                 // order (BGRA on Windows/D3D, RGBA on macOS/Metal), and reading it here
                 // handles any future backend changes automatically.
+                // A null format means the compositor returned an unusable snapshot
+                // (e.g. the visual tree isn't ready yet).  Skip the frame silently
+                // rather than trying to send garbage pixels.
+                if (snapshot.Format == null)
+                    return;
+
                 NDIlib.FourCC_type_e ndiFormat;
                 switch (snapshot.Format)
                 {
@@ -450,7 +466,7 @@ namespace EmoTracker.Extensions.NDI
                         ndiFormat = NDIlib.FourCC_type_e.FourCC_type_RGBA;
                         break;
                     default:
-                        Log.Warning("[NDI] Unsupported snapshot pixel format {Format}; defaulting to BGRA.", snapshot.Format);
+                        LogUnsupportedFormatWarning(snapshot.Format);
                         ndiFormat = NDIlib.FourCC_type_e.FourCC_type_BGRA;
                         break;
                 }


### PR DESCRIPTION
## Summary
- When `snapshot.Format` is `null` (compositor returns an unusable snapshot while the visual tree isn't ready), the capture now falls back to the platform default format (RGBA on macOS/Metal, BGRA on Windows/Linux) instead of skipping the frame
- For genuinely unsupported non-null pixel formats, the warning is now logged once per application run instead of repeatedly

## Test plan
- [ ] Open EmoTracker with a package that has a broadcast layout
- [ ] Open the Dev Console — verify no infinite \`[NDI] Unsupported snapshot pixel format null\` messages appear at startup
- [ ] Enable background NDI broadcast, verify the hidden window still streams correctly
- [ ] Open Broadcast View, verify NDI output works normally

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)