### PR TITLE
Fix broadcast view forcing always-on-top over main tracker window

### DIFF
--- a/EmoTracker/ApplicationModel.cs
+++ b/EmoTracker/ApplicationModel.cs
@@ -199,10 +199,10 @@ namespace EmoTracker
                 mBroadcastView = new BroadcastView();
                 mBroadcastView.Closing += (_, _) => mBroadcastView = null;
 
-                var mainWindow = (Avalonia.Application.Current?.ApplicationLifetime
-                    as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow;
-
-                mBroadcastView.Show(mainWindow);
+                // Show without an owner so the broadcast view is an independent
+                // top-level window.  Passing the main window as owner causes the
+                // OS to force the broadcast view above the main window at all times.
+                mBroadcastView.Show();
             }
             else
             {


### PR DESCRIPTION
## Summary
- `BroadcastView` was being shown with `Show(mainWindow)`, making it an owned window of the main window
- OS z-order rules force owned windows to always appear above their owner, so the broadcast view could never be hidden behind the tracker
- Changed to `Show()` (no owner) so it's an independent top-level window with normal z-order behaviour

## Test plan
- [ ] Open a pack, open Broadcast View (F2)
- [ ] Click the main tracker window — verify broadcast view goes behind it
- [ ] Alt-tab between windows normally

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)