### PR TITLE
Fix map location blips clipped at map boundaries

### DIFF
--- a/EmoTracker/UI/LocationMapControl.axaml
+++ b/EmoTracker/UI/LocationMapControl.axaml
@@ -71,11 +71,12 @@
                         <Grid Name="MapHost" Margin="25,25">
                             <controls:InputMaskingImage Name="MapImage"
                                                         Source="{Binding Image, Converter={x:Static converters:ImageReferenceConverter.Instance}}"/>
-                            <ItemsControl ItemsSource="{Binding Locations}">
+                            <ItemsControl ItemsSource="{Binding Locations}" ClipToBounds="False">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <Canvas Width="{Binding #MapImage.Source.Size.Width}"
-                                                Height="{Binding #MapImage.Source.Size.Height}"/>
+                                                Height="{Binding #MapImage.Source.Size.Height}"
+                                                ClipToBounds="False"/>
                                     </ItemsPanelTemplate>
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemContainerTheme>


### PR DESCRIPTION
## Summary
- The `ItemsControl` rendering map location blips uses a `Canvas` sized exactly to the map image, and both the `ItemsControl` and `Canvas` were clipping overflow by default in Avalonia
- Added `ClipToBounds="False"` to both the `ItemsControl` and its `Canvas` `ItemsPanel` so blip markers near the map edge are fully visible, restoring v2 behaviour

## Test plan
- [ ] Open CodeTracker, navigate to the Overworld map
- [ ] Find a map location blip near the edge of the map image — verify it renders fully, not cut off
- [ ] Verify badge icons near map edges are also unclipped

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)