### PR TITLE
Fix missing backgrounds in RecentPinnedLocations and GroupBox

### DIFF
--- a/EmoTracker/UI/LayoutControl.axaml
+++ b/EmoTracker/UI/LayoutControl.axaml
@@ -56,6 +56,7 @@
                 </LayoutTransformControl.LayoutTransform>
                 <Grid Width="{Binding Width, Converter={x:Static converters:NegativeToNaNDoubleConverter.Instance}}"
                       Height="{Binding Height, Converter={x:Static converters:NegativeToNaNDoubleConverter.Instance}}"
+                      Background="{Binding Background, Converter={x:Static converters:StringToBrushConverter.Instance}}"
                       IsHitTestVisible="{Binding HitTestVisible}"
                       MinWidth="{Binding MinWidth, Converter={x:Static converters:NegativeToZeroDoubleConverter.Instance}}"
                       MinHeight="{Binding MinHeight, Converter={x:Static converters:NegativeToZeroDoubleConverter.Instance}}"
@@ -372,7 +373,7 @@
                     </Grid>
                     <!-- Content area -->
                     <Grid Grid.Row="1"
-                          Background="{Binding Background, Converter={x:Static converters:StringToBrushConverter.Instance}, FallbackValue=#66212121}">
+                          Background="{Binding Background, Converter={x:Static converters:StringToBrushConverter.Instance}, TargetNullValue=#66212121, FallbackValue=#66212121}">
                         <ItemsControl ItemsSource="{Binding Items}" Margin="5"
                                       ItemContainerTheme="{StaticResource StretchItemContainer}">
                             <ItemsControl.ItemsPanel>

--- a/EmoTracker/UI/LayoutControl.axaml
+++ b/EmoTracker/UI/LayoutControl.axaml
@@ -410,15 +410,20 @@
                       Effect="{Binding DropShadow, Converter={x:Static converters:BoolToDropShadowEffectConverter.Instance}}">
                     <ScrollViewer HorizontalScrollBarVisibility="{Binding HorizontalScrollBarVisibility, Converter={x:Static converters:TrivialEnumConverter.Instance}}"
                                   VerticalScrollBarVisibility="{Binding VerticalScrollBarVisibility, Converter={x:Static converters:TrivialEnumConverter.Instance}}">
-                        <!-- MinHeight ensures the content fills at least the visible viewport area.
-                             Without this, Avalonia's ScrollViewer passes infinite height to content,
-                             which prevents DockPanel LastChildFill from allocating remaining space
-                             to the last child (e.g. the Pinned Locations GroupBox). By constraining
-                             content to at least the viewport height, the DockPanel receives a finite
-                             height and LastChildFill works correctly, while content taller than the
-                             viewport still scrolls normally. -->
+                        <!-- Use a Grid panel (not the default StackPanel) so the single content
+                             child is stretched to fill the ItemsControl's full arranged height.
+                             MinHeight ties that height to the ScrollViewer's visible viewport so
+                             DockPanel LastChildFill receives a finite height and allocates the
+                             remaining space to the last child (e.g. the Pinned Locations GroupBox).
+                             Content taller than the viewport still overflows and scrolls normally. -->
                         <ItemsControl ItemsSource="{Binding Items}"
-                                      MinHeight="{Binding $parent[ScrollViewer].Bounds.Height}" />
+                                      MinHeight="{Binding $parent[ScrollViewer].Bounds.Height}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <Grid />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
                     </ScrollViewer>
                 </Grid>
             </LayoutTransformControl>

--- a/EmoTracker/UI/LayoutControl.axaml
+++ b/EmoTracker/UI/LayoutControl.axaml
@@ -410,7 +410,15 @@
                       Effect="{Binding DropShadow, Converter={x:Static converters:BoolToDropShadowEffectConverter.Instance}}">
                     <ScrollViewer HorizontalScrollBarVisibility="{Binding HorizontalScrollBarVisibility, Converter={x:Static converters:TrivialEnumConverter.Instance}}"
                                   VerticalScrollBarVisibility="{Binding VerticalScrollBarVisibility, Converter={x:Static converters:TrivialEnumConverter.Instance}}">
-                        <ItemsControl ItemsSource="{Binding Items}" />
+                        <!-- MinHeight ensures the content fills at least the visible viewport area.
+                             Without this, Avalonia's ScrollViewer passes infinite height to content,
+                             which prevents DockPanel LastChildFill from allocating remaining space
+                             to the last child (e.g. the Pinned Locations GroupBox). By constraining
+                             content to at least the viewport height, the DockPanel receives a finite
+                             height and LastChildFill works correctly, while content taller than the
+                             viewport still scrolls normally. -->
+                        <ItemsControl ItemsSource="{Binding Items}"
+                                      MinHeight="{Binding $parent[ScrollViewer].Bounds.Height}" />
                     </ScrollViewer>
                 </Grid>
             </LayoutTransformControl>


### PR DESCRIPTION
## Summary

Three fixes in `LayoutControl.axaml`:

1. **RecentPinnedLocations background**: The `Grid` in the template was missing a `Background` binding entirely. Added the same `StringToBrushConverter` binding used by all other container templates.

2. **GroupBox `TargetNullValue`**: The content area background binding used `FallbackValue=#66212121`, which only fires on binding *errors*. Changed to `TargetNullValue` so the default semi-transparent dark fill applies whenever the converter returns `null`.

3. **ScrollPanel viewport fill for DockPanel LastChildFill**: The Pinned Locations GroupBox (last child of a `DockPanel` inside a `ScrollPanel`) was not expanding to fill the remaining vertical space. Root cause and fix described below.

---

### Root cause: Pinned Locations not filling remaining dock space

Avalonia's `ScrollViewer` with `VerticalScrollBarVisibility=Hidden` passes **infinite height** to its content. The inner `DockPanel` therefore also receives infinite height, causing `LastChildFill` to allocate infinite remaining space to the GroupBox. The GroupBox's `Grid` (auto-height) then measures its `Height="*"` content row as zero when the pin list is empty, so the background is invisible.

The `StackPanel` default items panel made this worse: even when `MinHeight` was applied to the `ItemsControl`, the StackPanel gives each child only its *desired* height — never propagating the viewport height constraint down to the `DockPanel`.

### Fix

- **Grid items panel**: Switched the `ScrollPanel` items panel from the default `StackPanel` to an explicit `Grid`. A `Grid` stretches its single content child to fill the full arranged height, so the `DockPanel` receives a finite height and `LastChildFill` allocates the remaining space to the GroupBox correctly — both at startup and after unpinning all locations.
- **`MinHeight` binding**: `MinHeight="{Binding $parent[ScrollViewer].Bounds.Height}"` ensures the `Grid` is at least as tall as the visible viewport, even when content is shorter. Content taller than the viewport still overflows and scrolls normally.

## Test plan
- [ ] Open CodeTracker in vertical layout — verify Pinned Locations GroupBox fills the bottom of the left panel with a dark background even when the list is empty
- [ ] Pin several locations — verify they appear correctly inside the GroupBox
- [ ] Unpin all locations — verify the GroupBox retains its fill (does not collapse)
- [ ] Verify groups with an explicit `background` JSON value still use that colour
- [ ] Resize the window — verify the GroupBox adjusts correctly

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)