### PR TITLE
Fix badge icons showing only bottom-right quadrant

### DIFF
--- a/EmoTracker.Data/Locations/Map.cs
+++ b/EmoTracker.Data/Locations/Map.cs
@@ -131,10 +131,10 @@ namespace EmoTracker.Data.Locations
 
         private void UpdateBadgeMargin()
         {
-            // Place the top-left corner of the badge at the centre of the location
-            // dot.  The badge then extends to the lower-right, reproducing the v2
-            // behaviour where the badge overlapped the dot's corner.
-            mBadgeMargin = new Thickness(mSize * 0.5, mSize * 0.5, 0, 0);
+            // Centre the badge on the location dot: offset the badge's top-left by
+            // (dotCentre - badgeSize/2) so the badge is symmetrically overlaid on the dot.
+            double offset = (mSize - mBadgeSize) * 0.5;
+            mBadgeMargin = new Thickness(offset, offset, 0, 0);
             NotifyPropertyChanged("BadgeMargin");
         }
 

--- a/EmoTracker.Data/Locations/Map.cs
+++ b/EmoTracker.Data/Locations/Map.cs
@@ -131,7 +131,10 @@ namespace EmoTracker.Data.Locations
 
         private void UpdateBadgeMargin()
         {
-            mBadgeMargin = new Thickness((mSize * 0.5) + (mBadgeSize * -0.5), (mSize * 0.5) + (mBadgeSize * -0.5), 0, 0);
+            // Place the top-left corner of the badge at the centre of the location
+            // dot.  The badge then extends to the lower-right, reproducing the v2
+            // behaviour where the badge overlapped the dot's corner.
+            mBadgeMargin = new Thickness(mSize * 0.5, mSize * 0.5, 0, 0);
             NotifyPropertyChanged("BadgeMargin");
         }
 

--- a/EmoTracker/UI/LocationMapControl.axaml
+++ b/EmoTracker/UI/LocationMapControl.axaml
@@ -86,7 +86,7 @@
                                 </ItemsControl.ItemContainerTheme>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate DataType="locations:MapLocation">
-                                        <Grid Name="MinifiedLocation">
+                                        <Grid Name="MinifiedLocation" ClipToBounds="False">
                                             <Grid.IsVisible>
                                                 <MultiBinding Converter="{x:Static converters:MapLocationVisibilityConverter.Instance}">
                                                     <Binding Path="ForceVisible" />
@@ -129,13 +129,18 @@
                                                 </Viewbox>
                                             </Border>
 
-                                            <!-- Badges host -->
+                                            <!-- Badges host: top-left corner of each badge is placed at the
+                                                 center of the location dot (size/2, size/2), so the badge
+                                                 overlaps the dot corner and extends to the lower-right.
+                                                 Margin is applied to the ItemsControl directly; the Grid
+                                                 panel has no margin so items render from (0,0) within it. -->
                                             <ItemsControl ItemsSource="{Binding Location.Badges}"
-                                                          VerticalAlignment="Bottom"
-                                                          HorizontalAlignment="Right">
+                                                          VerticalAlignment="Top"
+                                                          HorizontalAlignment="Left"
+                                                          Margin="{Binding DataContext.BadgeMargin, ElementName=MinifiedLocation, Converter={x:Static converters:ThicknessConverter.Instance}}">
                                                 <ItemsControl.ItemsPanel>
                                                     <ItemsPanelTemplate>
-                                                        <Grid Margin="{Binding DataContext.BadgeMargin, ElementName=MinifiedLocation, Converter={x:Static converters:ThicknessConverter.Instance}}"/>
+                                                        <Grid />
                                                     </ItemsPanelTemplate>
                                                 </ItemsControl.ItemsPanel>
                                                 <ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary

Badge icons (e.g. captured entrance indicators) were rendering incorrectly in Avalonia — only the bottom-right quadrant was visible rather than the badge being centred on the location dot.

**Root cause**: In Avalonia, applying `Margin` to a `Grid` used as an `ItemsPanel` does not offset items the same way as in WPF, causing the badge to render at the wrong position.

**Changes:**
- Move `BadgeMargin` from the `Grid` panel to the `ItemsControl` itself, with `HorizontalAlignment="Left"` / `VerticalAlignment="Top"`, so Avalonia applies the margin correctly at the container level
- Update `BadgeMargin` formula to `(size - badgeSize) / 2` on each axis, centring the badge over the location dot (matching WPF v2 behaviour)
- Set `ClipToBounds="False"` on the `MinifiedLocation` Grid so badge overflow beyond the location dot bounds is visible

**Note**: An intermediate version of this PR used `size / 2` as the formula, which incorrectly placed the badge's top-left corner at the dot centre (bottom-right offset). The correct formula is `(size - badgeSize) / 2`, which centres the badge symmetrically over the dot.

## Test plan
- [ ] Open CodeTracker with Entrance Mode enabled
- [ ] Capture an entrance — verify the badge icon is centred on the location dot
- [ ] Verify the badge does not appear clipped or offset to one side

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)