### PR TITLE
Fix item hitbox ignoring transparency

### DIFF
--- a/EmoTracker.UI/Controls/InputMaskingImage.cs
+++ b/EmoTracker.UI/Controls/InputMaskingImage.cs
@@ -5,30 +5,16 @@ using EmoTracker.UI.Media.Utility;
 
 namespace EmoTracker.UI.Controls
 {
-    // Avalonia version: per-pixel hit testing uses the precomputed alpha mask from IconUtility.
-    // The correct HitTestCore override will be wired up in Phase 6 once the Avalonia control
-    // hierarchy is fully understood. For now, pointer event filtering handles transparent areas.
+    // Avalonia version: per-pixel hit testing via HitTestCore so transparent pixels
+    // are excluded from Avalonia's visual hit-test walk.  This prevents transparent
+    // areas from blocking pointer events on elements below in z-order.
     public class InputMaskingImage : Image
     {
-        protected override void OnPointerMoved(PointerEventArgs e)
+        protected override bool HitTestCore(PointHitTestParameters hitTestParameters)
         {
-            if (!HitTestAlphaMask(e.GetPosition(this)))
-                return;
-            base.OnPointerMoved(e);
-        }
-
-        protected override void OnPointerPressed(PointerPressedEventArgs e)
-        {
-            if (!HitTestAlphaMask(e.GetPosition(this)))
-                return;
-            base.OnPointerPressed(e);
-        }
-
-        protected override void OnPointerReleased(PointerReleasedEventArgs e)
-        {
-            if (!HitTestAlphaMask(e.GetPosition(this)))
-                return;
-            base.OnPointerReleased(e);
+            if (!HitTestAlphaMask(hitTestParameters.HitPoint))
+                return false;
+            return base.HitTestCore(hitTestParameters);
         }
 
         private bool HitTestAlphaMask(Avalonia.Point point)

--- a/EmoTracker.UI/Controls/InputMaskingImage.cs
+++ b/EmoTracker.UI/Controls/InputMaskingImage.cs
@@ -1,20 +1,17 @@
 using Avalonia.Controls;
-using Avalonia.Input;
-using Avalonia.Media;
+using Avalonia.Rendering;
 using EmoTracker.UI.Media.Utility;
 
 namespace EmoTracker.UI.Controls
 {
-    // Avalonia version: per-pixel hit testing via HitTestCore so transparent pixels
+    // Avalonia version: per-pixel hit testing via ICustomHitTest so transparent pixels
     // are excluded from Avalonia's visual hit-test walk.  This prevents transparent
     // areas from blocking pointer events on elements below in z-order.
-    public class InputMaskingImage : Image
+    public class InputMaskingImage : Image, ICustomHitTest
     {
-        protected override bool HitTestCore(PointHitTestParameters hitTestParameters)
+        public bool HitTest(Avalonia.Point point)
         {
-            if (!HitTestAlphaMask(hitTestParameters.HitPoint))
-                return false;
-            return base.HitTestCore(hitTestParameters);
+            return HitTestAlphaMask(point);
         }
 
         private bool HitTestAlphaMask(Avalonia.Point point)


### PR DESCRIPTION
## Summary
`InputMaskingImage` was using pointer-event filtering (`OnPointerPressed` etc.) to suppress clicks on transparent pixels, but this approach doesn't work for items stacked in z-order. Avalonia's hit-test walk picks the front-most element that passes `HitTestCore` (which defaulted to the full bounding box), routes the event there, and stops — so the transparent area of one item would consume clicks intended for the item below it.

**Fix:** Replace the event-filter approach with a proper `HitTestCore` override. When `HitTestCore` returns `false`, Avalonia continues its hit-test walk to the next element in z-order, so transparent pixels cleanly pass through to whatever is beneath them.

## Test plan
- [ ] Open CodeTracker Items/Key Tracker variant
- [ ] Click on the Prize Shuffle icon's transparent corners — verify clicks pass through to items underneath
- [ ] Verify opaque parts of items still respond to clicks normally

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)