### PR TITLE
Fix excessive line spacing in GroupBox popout layouts

### DIFF
--- a/EmoTracker/UI/LayoutControl.axaml
+++ b/EmoTracker/UI/LayoutControl.axaml
@@ -6,7 +6,8 @@
              xmlns:converters="clr-namespace:EmoTracker.UI.Converters;assembly=EmoTracker.UI"
              xmlns:data="clr-namespace:EmoTracker.Data;assembly=EmoTracker.Data"
              xmlns:layout="clr-namespace:EmoTracker.Data.Layout;assembly=EmoTracker.Data"
-             xmlns:local="clr-namespace:EmoTracker.UI">
+             xmlns:local="clr-namespace:EmoTracker.UI"
+             FontSize="12">
     <UserControl.Resources>
         <!-- In WPF, ContentPresenter.HorizontalContentAlignment defaults to Stretch.
              In Avalonia it defaults to Left, so item container ContentPresenters size
@@ -113,11 +114,14 @@
                                   ItemContainerTheme="{StaticResource StretchItemContainer}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <!-- Orientation is bound via RelativeSource to the owning ItemsControl's DataContext (the ArrayPanel).
-                                     TrivialEnumConverter maps EmoTracker.Data.Layout.Orientation → Avalonia.Layout.Orientation. -->
-                                <StackPanel Orientation="{Binding DataContext.Orientation,
-                                    RelativeSource={RelativeSource AncestorType=ItemsControl},
-                                    Converter={x:Static converters:TrivialEnumConverter.Instance}}" />
+                                <!-- The StackPanel inherits DataContext from the ItemsControl (the
+                                     ArrayPanel model), so we can bind Orientation directly without
+                                     RelativeSource.  RelativeSource AncestorType bindings inside
+                                     ItemsPanelTemplate are unreliable in Avalonia because the panel
+                                     is not yet in the visual tree when the binding is first evaluated,
+                                     causing the orientation to silently default to Vertical for all
+                                     arrays and collapsing horizontal layouts into a single column. -->
+                                <StackPanel Orientation="{Binding Orientation, Converter={x:Static converters:TrivialEnumConverter.Instance}}" />
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                     </ItemsControl>

--- a/EmoTracker/UI/LayoutControl.axaml
+++ b/EmoTracker/UI/LayoutControl.axaml
@@ -387,7 +387,7 @@
                                       ItemContainerTheme="{StaticResource StretchItemContainer}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
-                                    <Grid />
+                                    <StackPanel Orientation="Vertical" />
                                 </ItemsPanelTemplate>
                             </ItemsControl.ItemsPanel>
                         </ItemsControl>


### PR DESCRIPTION
## Summary
- Fixes #10
- GroupBox `ItemsPanel`: `<Grid />` → `<StackPanel Orientation="Vertical" />` — with `StretchItemContainer`, a plain Grid stretches each ContentPresenter to the full Grid height, producing huge gaps between items
- Set `FontSize="12"` on LayoutControl — Avalonia Fluent theme defaults to 14px; WPF inherits Windows system font (~12px). Pack designers built for WPF so Avalonia's larger default inflates row heights
- Set `ClipToBounds="False"` on `ItemsControl` and `LayoutTransformControl` — WPF does not clip by default; pack makers use negative margins to overflow elements outside their containers
- Fix ArrayPanel orientation binding — `RelativeSource AncestorType=ItemsControl` silently fails in Avalonia's `ItemsPanelTemplate` (panel not in visual tree yet), causing all arrays to default to Vertical orientation; fixed by binding directly to the inherited DataContext

## Known remaining issue
Settings popup rows still show slightly more vertical spacing than the WPF version. Root cause not yet identified. Tracked in the PR comment below.

## Test plan
- [ ] Open a pack that uses GroupBox popout layouts — verify items stack normally
- [ ] Open settings popup (gear icon) — verify rows are reasonably compact
- [ ] Verify horizontal array panels render horizontally (not all collapsed to vertical)
- [ ] Verify elements that use negative margins are not clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)