### PR TITLE
Fix items specifying height-only or width-only dimension having wrong proportions

### DIFF
--- a/EmoTracker.UI/Converters/NumericConverters.cs
+++ b/EmoTracker.UI/Converters/NumericConverters.cs
@@ -114,28 +114,45 @@ namespace EmoTracker.UI.Converters
     }
 
     /// <summary>
-    /// Multi-value converter for icon dimensions. Returns the explicit dimension when it is
-    /// a valid positive number; otherwise falls back to the pixel dimensions of the bound
-    /// <see cref="Bitmap"/> source image. Use <c>ConverterParameter="Width"</c> or
-    /// <c>"Height"</c> to select which pixel dimension to read.
-    /// <para>values[0] = dimension (double, e.g. IconWidth), values[1] = Image.Source (IImage).</para>
+    /// Multi-value converter for icon dimensions. Supports three behaviours:
+    /// <list type="bullet">
+    ///   <item>Both dimensions specified → honor both (image may be distorted).</item>
+    ///   <item>Only this dimension specified → use it directly.</item>
+    ///   <item>Only the other dimension specified → compute this one proportionally from
+    ///     the source image's aspect ratio.</item>
+    ///   <item>Neither specified → fall back to the source image's natural pixel size.</item>
+    /// </list>
+    /// Use <c>ConverterParameter="Width"</c> or <c>"Height"</c> to select which dimension
+    /// is being resolved.
+    /// <para>values[0] = this dimension (IconWidth or IconHeight),
+    ///       values[1] = other dimension (IconHeight or IconWidth),
+    ///       values[2] = Image.Source (IImage, for aspect-ratio and pixel-size fallback).</para>
     /// </summary>
     public class IconDimensionMultiConverter : Singleton<IconDimensionMultiConverter>, IMultiValueConverter
     {
         public object Convert(IList<object> values, Type targetType, object parameter, CultureInfo culture)
         {
-            double dimension = values.Count > 0 && values[0] is double d ? d : double.NaN;
+            double myDim    = values.Count > 0 && values[0] is double d0 ? d0 : double.NaN;
+            double otherDim = values.Count > 1 && values[1] is double d1 ? d1 : double.NaN;
+            bool isWidth = string.Equals(parameter?.ToString(), "Width", StringComparison.OrdinalIgnoreCase);
+            Bitmap bitmap = values.Count > 2 ? values[2] as Bitmap : null;
 
-            // If the layout specifies a valid positive size, use it directly.
-            if (dimension > 0 && !double.IsNaN(dimension))
-                return dimension;
+            // If this dimension is explicitly specified (including zero), use it directly.
+            if (!double.IsNaN(myDim) && myDim >= 0)
+                return myDim;
 
-            // Fall back to the source image's pixel dimensions.
-            if (values.Count > 1 && values[1] is Bitmap bitmap)
+            // Only the other dimension was specified: scale proportionally from the image aspect ratio.
+            if (otherDim > 0 && !double.IsNaN(otherDim) && bitmap != null)
             {
-                bool useWidth = string.Equals(parameter?.ToString(), "Width", StringComparison.OrdinalIgnoreCase);
-                return (double)(useWidth ? bitmap.PixelSize.Width : bitmap.PixelSize.Height);
+                double pixW = bitmap.PixelSize.Width;
+                double pixH = bitmap.PixelSize.Height;
+                if (pixW > 0 && pixH > 0)
+                    return isWidth ? otherDim * pixW / pixH : otherDim * pixH / pixW;
             }
+
+            // Neither dimension specified: fall back to the image's natural pixel size.
+            if (bitmap != null)
+                return isWidth ? (double)bitmap.PixelSize.Width : (double)bitmap.PixelSize.Height;
 
             // Last resort default.
             return 32.0;

--- a/EmoTracker/UI/TrackableItemControl.axaml
+++ b/EmoTracker/UI/TrackableItemControl.axaml
@@ -17,7 +17,7 @@
                 BorderThickness="0">
             <Button.Template>
                 <ControlTemplate TargetType="Button">
-                    <Grid Background="Transparent">
+                    <Grid Background="{x:Null}">
                         <controls:InputMaskingImage
                             HorizontalAlignment="Left"
                             VerticalAlignment="Top"
@@ -25,12 +25,14 @@
                             <controls:InputMaskingImage.Width>
                                 <MultiBinding Converter="{x:Static converters:IconDimensionMultiConverter.Instance}" ConverterParameter="Width">
                                     <Binding Path="IconWidth" RelativeSource="{RelativeSource AncestorType=local:TrackableItemControl}" />
+                                    <Binding Path="IconHeight" RelativeSource="{RelativeSource AncestorType=local:TrackableItemControl}" />
                                     <Binding Path="Source" RelativeSource="{RelativeSource Self}" />
                                 </MultiBinding>
                             </controls:InputMaskingImage.Width>
                             <controls:InputMaskingImage.Height>
                                 <MultiBinding Converter="{x:Static converters:IconDimensionMultiConverter.Instance}" ConverterParameter="Height">
                                     <Binding Path="IconHeight" RelativeSource="{RelativeSource AncestorType=local:TrackableItemControl}" />
+                                    <Binding Path="IconWidth" RelativeSource="{RelativeSource AncestorType=local:TrackableItemControl}" />
                                     <Binding Path="Source" RelativeSource="{RelativeSource Self}" />
                                 </MultiBinding>
                             </controls:InputMaskingImage.Height>
@@ -38,7 +40,7 @@
                         <Grid VerticalAlignment="Bottom"
                               HorizontalAlignment="Right"
                               MaxWidth="{Binding IconWidth, RelativeSource={RelativeSource AncestorType=local:TrackableItemControl}}"
-                              IsVisible="{Binding BadgeText, Converter={x:Static converters:NonEmptyStringToBoolConverter.Instance}}">
+                              IsVisible="{Binding BadgeText, Converter={x:Static converters:NonEmptyStringToBoolConverter.Instance}, FallbackValue=False}">
                             <TextBlock Text="{Binding BadgeText}"
                                        Background="Black"
                                        FontWeight="Bold"


### PR DESCRIPTION
## Summary
- Fixes #4, #7
- `IconDimensionMultiConverter` now accepts three bindings: this dimension, the other dimension, and the image source. When only one dimension is specified, the missing dimension is derived from the image aspect ratio rather than falling back to the raw pixel size.
- Fixed the guard condition from `> 0` to `>= 0` so an explicit zero-dimension is honoured and doesn't fall into the proportional-scaling path.
- Added `FallbackValue=False` to BadgeText visibility binding to prevent flicker during binding initialisation.
- Changed Button template inner Grid background from `Transparent` to `{x:Null}` to avoid a background that unnecessarily consumes hit-test area.

## Test plan
- [ ] Load CodeTracker, open Key Tracker variant
- [ ] Verify Prize Shuffle icon displays correctly (overlaid on the 2x2 dungeon grid)
- [ ] Verify Modes popout menu displays correctly
- [ ] Verify items that specify only `h` (height) render at correct proportions instead of being stretched to square
- [ ] Verify items that specify only `w` (width) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)