### PR TITLE
Fix layout text rendering larger than v2

### DIFF
--- a/EmoTracker/UI/LayoutControl.axaml
+++ b/EmoTracker/UI/LayoutControl.axaml
@@ -6,7 +6,8 @@
              xmlns:converters="clr-namespace:EmoTracker.UI.Converters;assembly=EmoTracker.UI"
              xmlns:data="clr-namespace:EmoTracker.Data;assembly=EmoTracker.Data"
              xmlns:layout="clr-namespace:EmoTracker.Data.Layout;assembly=EmoTracker.Data"
-             xmlns:local="clr-namespace:EmoTracker.UI">
+             xmlns:local="clr-namespace:EmoTracker.UI"
+             FontSize="12">
     <UserControl.Resources>
         <!-- In WPF, ContentPresenter.HorizontalContentAlignment defaults to Stretch.
              In Avalonia it defaults to Left, so item container ContentPresenters size


### PR DESCRIPTION
## Summary
- Fixes #17
- Avalonia's Fluent theme has a larger default font size than WPF's system default (12px). Without an explicit `FontSize` on the root `LayoutControl`, all text inside layout popouts inherits the theme default, making it appear larger than v2.
- Adding `FontSize="12"` to the `LayoutControl` UserControl element anchors all descendant text to the WPF-equivalent size.

## Test plan
- [ ] Load CodeTracker, open any popout with text (e.g. the modal popup with ButtonPopup/scaling)
- [ ] Verify text renders at the same size as v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)