### PR TITLE
Fix container overlay items displaying outside bounds

### DIFF
--- a/EmoTracker/App.axaml
+++ b/EmoTracker/App.axaml
@@ -6,6 +6,52 @@
 
     <Application.Styles>
         <FluentTheme />
+        <!-- WPF layout containers don't clip children by default. Pack makers rely on negative
+             margins to intentionally overflow elements (e.g. close buttons positioned outside
+             their containing box). Override ClipToBounds on every possible panel/control type
+             to match WPF behaviour throughout the layout tree. -->
+        <Style Selector="Panel">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="Grid">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="StackPanel">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="WrapPanel">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="DockPanel">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="ItemsControl">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="ContentControl">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="ContentPresenter">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="LayoutTransformControl">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="Border">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="Decorator">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="Viewbox">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="ScrollContentPresenter">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+        <Style Selector="ItemsPresenter">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
     </Application.Styles>
 
     <Application.Resources>

--- a/EmoTracker/UI/ItemGridControl.axaml
+++ b/EmoTracker/UI/ItemGridControl.axaml
@@ -9,18 +9,20 @@
         RenderOptions.BitmapInterpolationMode="None" on each Image element, or globally via
         a style. BitmapCache has no direct equivalent; Avalonia handles caching internally.
     -->
-    <Grid Margin="{Binding LegacyMargin, Converter={x:Static converters:StringToThicknessConverter.Instance}}">
+    <Grid Margin="{Binding LegacyMargin, Converter={x:Static converters:StringToThicknessConverter.Instance}}"
+          ClipToBounds="False">
         <Grid.Resources>
             <ItemsPanelTemplate x:Key="HorizontalItemsPanel">
-                <StackPanel Orientation="Horizontal" />
+                <StackPanel Orientation="Horizontal" ClipToBounds="False" />
             </ItemsPanelTemplate>
         </Grid.Resources>
-        <ItemsControl ItemsSource="{Binding Path=Rows}">
+        <ItemsControl ItemsSource="{Binding Path=Rows}" ClipToBounds="False">
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <Grid MinHeight="10">
+                    <Grid MinHeight="10" ClipToBounds="False">
                         <ItemsControl ItemsSource="{Binding}"
                                       HorizontalAlignment="Center"
+                                      ClipToBounds="False"
                                       ItemsPanel="{StaticResource HorizontalItemsPanel}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>

--- a/EmoTracker/UI/LayoutControl.axaml
+++ b/EmoTracker/UI/LayoutControl.axaml
@@ -17,6 +17,15 @@
             <Setter Property="VerticalContentAlignment" Value="Stretch" />
         </ControlTheme>
     </UserControl.Resources>
+    <UserControl.Styles>
+        <!-- LayoutTransformControl overrides ClipToBounds to true in its static constructor.
+             Application.Styles is too far from the element for that override to be beaten
+             reliably; a UserControl-scoped style wins via proximity. All other element types
+             are covered by the global Application.Styles in App.axaml. -->
+        <Style Selector="LayoutTransformControl">
+            <Setter Property="ClipToBounds" Value="False"/>
+        </Style>
+    </UserControl.Styles>
     <UserControl.DataTemplates>
 
         <!-- Each DataTemplate wraps its content in a LayoutTransformControl so that the
@@ -475,8 +484,9 @@
                       MinHeight="{Binding MinHeight, Converter={x:Static converters:NegativeToZeroDoubleConverter.Instance}}"
                       MaxWidth="{Binding MaxWidth, Converter={x:Static converters:NegativeToInfinityDoubleConverter.Instance}}"
                       MaxHeight="{Binding MaxHeight, Converter={x:Static converters:NegativeToInfinityDoubleConverter.Instance}}"
-                      Effect="{Binding DropShadow, Converter={x:Static converters:BoolToDropShadowEffectConverter.Instance}}">
-                    <local:ItemGridControl DataContext="{Binding Data}" />
+                      Effect="{Binding DropShadow, Converter={x:Static converters:BoolToDropShadowEffectConverter.Instance}}"
+                      ClipToBounds="False">
+                    <local:ItemGridControl DataContext="{Binding Data}" ClipToBounds="False" />
                 </Grid>
             </LayoutTransformControl>
         </DataTemplate>

--- a/EmoTracker/UI/TrackableItemControl.axaml
+++ b/EmoTracker/UI/TrackableItemControl.axaml
@@ -14,7 +14,9 @@
                 Focusable="False"
                 Background="{x:Null}"
                 Padding="0"
-                BorderThickness="0">
+                BorderThickness="0"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch">
             <Button.Template>
                 <ControlTemplate TargetType="Button">
                     <Grid Background="{x:Null}">


### PR DESCRIPTION
## Summary
- Fixes #12
- Avalonia sets `ClipToBounds=true` by default on most layout containers, unlike WPF which leaves it false. Pack makers rely on negative margins and overflow rendering (overlay items positioned outside their container bounds) which are silently clipped in Avalonia.
- Adds global `Application.Styles` setting `ClipToBounds=False` on all common layout container types: `Grid`, `StackPanel`, `Panel`, `WrapPanel`, `DockPanel`, `ItemsControl`, `ContentControl`, `ContentPresenter`, `Border`, `Decorator`, `Viewbox`, `ScrollContentPresenter`, `ItemsPresenter`.
- `LayoutTransformControl` overrides `ClipToBounds` in its static constructor so it can't be beaten by `Application.Styles`; a `UserControl`-scoped style is added to `LayoutControl` to win via style proximity.
- Explicitly sets `ClipToBounds=False` on `ItemGridControl` inner elements for belt-and-suspenders coverage.
- Adds `HorizontalAlignment/VerticalAlignment=Stretch` to the `Button` in `TrackableItemControl` so it fills its grid cell correctly.

## Test plan
- [ ] Load CodeTracker, switch Alternate Layout to 2 in Settings Tab
- [ ] Verify overlay items display in the correct position over the item grid
- [ ] Open the Doors Tab, select a dungeon, click 4 rooms — verify `?` icons appear correctly over doors
- [ ] Verify no visual regression in other layout types or map displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)