### PR TITLE
Add font_size support to Text layout element

### DIFF
--- a/EmoTracker.Data/Layout/TextBlock.cs
+++ b/EmoTracker.Data/Layout/TextBlock.cs
@@ -10,6 +10,7 @@ namespace EmoTracker.Data.Layout
     public class TextBlock : LayoutItem
     {
         string mText;
+        double mFontSize = -1.0;
 
         public string Text
         {
@@ -17,9 +18,20 @@ namespace EmoTracker.Data.Layout
             set { SetProperty(ref mText, value); }
         }
 
+        /// <summary>
+        /// Font size for the text element, in points. A value of -1.0 (the default) means
+        /// "not set" — the rendered control will inherit the font size from the visual tree.
+        /// </summary>
+        public double FontSize
+        {
+            get { return mFontSize; }
+            set { SetProperty(ref mFontSize, value); }
+        }
+
         protected override bool TryParseInternal(JObject data, IGamePackage package)
         {
             Text = data.GetValue<string>("text");
+            FontSize = data.GetValue<double>("font_size", -1.0);
             return true;
         }
     }

--- a/EmoTracker/UI/LayoutControl.axaml
+++ b/EmoTracker/UI/LayoutControl.axaml
@@ -552,7 +552,8 @@
                       MaxWidth="{Binding MaxWidth, Converter={x:Static converters:NegativeToInfinityDoubleConverter.Instance}}"
                       MaxHeight="{Binding MaxHeight, Converter={x:Static converters:NegativeToInfinityDoubleConverter.Instance}}"
                       Effect="{Binding DropShadow, Converter={x:Static converters:BoolToDropShadowEffectConverter.Instance}}">
-                    <TextBlock Text="{Binding Text}" />
+                    <TextBlock Text="{Binding Text}"
+                               FontSize="{Binding FontSize, Converter={x:Static converters:NegativeToUnsetConverter.Instance}}" />
                 </Grid>
             </LayoutTransformControl>
         </DataTemplate>


### PR DESCRIPTION
## Summary

- Adds a `font_size` JSON property to the `text` layout element type in `EmoTracker.Data/Layout/TextBlock.cs`
- Default value is `-1.0` (sentinel for "not set") — when unspecified, the rendered `TextBlock` inherits its font size from the Avalonia visual tree
- When set to a positive number, the value is applied as `FontSize` on the Avalonia `TextBlock` control via the existing `NegativeToUnsetConverter`
- No new converters needed — `NegativeToUnsetConverter` already returns `AvaloniaProperty.UnsetValue` for negative inputs, which causes the binding to fall back to the inherited/default value

## Example usage

```json
{
  "type": "text",
  "text": "Hello World",
  "font_size": 18
}
```

## Test plan

- [ ] Layout JSON with no `font_size` field: text renders using inherited font size (no change from before)
- [ ] Layout JSON with `font_size: 18`: text renders at 18pt
- [ ] Layout JSON with `font_size: -1`: treated as "not set", inherits font size (same as omitting the field)
- [ ] Build with `dotnet build` — 0 errors, 0 warnings ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)