### PR TITLE
Add MCP dev server extension for AI-assisted testing

### DIFF
--- a/EmoTracker.Data/ScriptManager.cs
+++ b/EmoTracker.Data/ScriptManager.cs
@@ -484,6 +484,28 @@ function print(...)
         }
 
         [NLua.LuaHide]
+        public object[] ExecuteLuaString(string luaCode)
+        {
+            if (mLua == null)
+                throw new InvalidOperationException("No Lua environment is loaded");
+            return mLua.DoString(luaCode);
+        }
+
+        [NLua.LuaHide]
+        public object GetLuaGlobal(string name)
+        {
+            if (mLua == null)
+                throw new InvalidOperationException("No Lua environment is loaded");
+            return mLua[name];
+        }
+
+        [NLua.LuaHide]
+        public bool IsLuaLoaded
+        {
+            get { return mLua != null; }
+        }
+
+        [NLua.LuaHide]
         public object FindObjectForCode(string code)
         {
             return null;

--- a/EmoTracker/EmoTracker.csproj
+++ b/EmoTracker/EmoTracker.csproj
@@ -10,6 +10,11 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <!-- ASP.NET Core framework for MCP server SSE transport (dev mode only) -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <!-- PluginManager.cs is intentionally excluded from compilation -->
   <ItemGroup>
     <Compile Remove="PluginManager.cs" />
@@ -50,6 +55,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="TwitchLib" Version="3.5.3" />
     <PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" NoWarn="NU1701" />

--- a/EmoTracker/EmoTracker.csproj
+++ b/EmoTracker/EmoTracker.csproj
@@ -10,14 +10,18 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
-  <!-- ASP.NET Core framework for MCP server SSE transport (dev mode only) -->
-  <ItemGroup>
+  <!-- MCP dev server: only included in Debug builds -->
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <!-- PluginManager.cs is intentionally excluded from compilation -->
+  <!-- MCP server extension is excluded from Release builds -->
   <ItemGroup>
     <Compile Remove="PluginManager.cs" />
+    <Compile Remove="Extensions\McpServer\**\*" Condition="'$(Configuration)' != 'Debug'" />
+    <AvaloniaXaml Remove="Extensions\McpServer\**\*" Condition="'$(Configuration)' != 'Debug'" />
+    <AvaloniaResource Remove="Extensions\McpServer\**\*" Condition="'$(Configuration)' != 'Debug'" />
   </ItemGroup>
 
   <!-- Avalonia resource items — accessible via avares://EmoTracker/... -->
@@ -55,8 +59,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.2.0" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="TwitchLib" Version="3.5.3" />
     <PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" NoWarn="NU1701" />

--- a/EmoTracker/Extensions/McpServer/McpServerExtension.cs
+++ b/EmoTracker/Extensions/McpServer/McpServerExtension.cs
@@ -104,6 +104,13 @@ namespace EmoTracker.Extensions.McpServer
                 .WithTools<Tools.LuaTools>()
                 .WithTools<Tools.ScreenshotTools>()
                 .WithTools<Tools.UiAutomationTools>()
+                .WithTools<Tools.SettingsTools>()
+                .WithTools<Tools.LocationTools>()
+                .WithTools<Tools.SaveLoadTools>()
+                .WithTools<Tools.WindowTools>()
+                .WithTools<Tools.NoteTools>()
+                .WithTools<Tools.ExtensionTools>()
+                .WithTools<Tools.PackageTools>()
                 .WithHttpTransport();
 
                 mApp = builder.Build();

--- a/EmoTracker/Extensions/McpServer/McpServerExtension.cs
+++ b/EmoTracker/Extensions/McpServer/McpServerExtension.cs
@@ -1,0 +1,132 @@
+using EmoTracker.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using Newtonsoft.Json.Linq;
+using Serilog;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer
+{
+    public class McpServerExtension : ObservableObject, Extension
+    {
+        const int DefaultPort = 27125;
+
+        public string Name => "MCP Dev Server";
+        public string UID => "emotracker_mcp_server";
+        public int Priority => -500;
+
+        private bool mbActive;
+        public bool Active
+        {
+            get => mbActive;
+            private set => SetProperty(ref mbActive, value);
+        }
+
+        private string mStatusText = "Stopped";
+        public string StatusText
+        {
+            get => mStatusText;
+            private set => SetProperty(ref mStatusText, value);
+        }
+
+        private WebApplication mApp;
+        private McpStatusIndicator mStatusBarControl;
+
+        public object StatusBarControl
+        {
+            get
+            {
+                if (!UserDirectory.IsDevMode)
+                    return null;
+
+                if (mStatusBarControl == null)
+                    mStatusBarControl = new McpStatusIndicator { DataContext = this };
+                return mStatusBarControl;
+            }
+        }
+
+        public void Start()
+        {
+            if (!UserDirectory.IsDevMode)
+                return;
+
+            _ = StartServerAsync();
+        }
+
+        public void Stop()
+        {
+            if (mApp != null)
+            {
+                try
+                {
+                    mApp.StopAsync().GetAwaiter().GetResult();
+                    mApp.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "[MCP] Error stopping server");
+                }
+                mApp = null;
+                Active = false;
+                StatusText = "Stopped";
+            }
+        }
+
+        private async Task StartServerAsync()
+        {
+            try
+            {
+                int port = DefaultPort;
+                string portEnv = Environment.GetEnvironmentVariable("EMOTRACKER_MCP_PORT");
+                if (!string.IsNullOrEmpty(portEnv) && int.TryParse(portEnv, out int envPort))
+                    port = envPort;
+
+                var builder = WebApplication.CreateBuilder();
+                builder.WebHost.UseUrls($"http://localhost:{port}");
+
+                builder.Logging.ClearProviders();
+
+                builder.Services.AddMcpServer(options =>
+                {
+                    options.ServerInfo = new()
+                    {
+                        Name = "EmoTracker Dev Server",
+                        Version = ApplicationVersion.Current.ToString()
+                    };
+                })
+                .WithTools<Tools.PackDataTools>()
+                .WithTools<Tools.ApplicationControlTools>()
+                .WithTools<Tools.LuaTools>()
+                .WithTools<Tools.ScreenshotTools>()
+                .WithTools<Tools.UiAutomationTools>()
+                .WithHttpTransport();
+
+                mApp = builder.Build();
+                mApp.MapMcp();
+
+                await mApp.StartAsync();
+
+                Active = true;
+                StatusText = $"Listening on port {port}";
+                Log.Information("[MCP] Server listening on port {Port}", port);
+            }
+            catch (Exception ex)
+            {
+                Active = false;
+                StatusText = $"Error: {ex.Message}";
+                Log.Error(ex, "[MCP] Failed to start server");
+            }
+        }
+
+        public void OnPackageUnloaded() { }
+        public void OnPackageLoaded() { }
+
+        public JToken SerializeToJson() => null;
+        public bool DeserializeFromJson(JToken token) => true;
+    }
+}

--- a/EmoTracker/Extensions/McpServer/McpStatusIndicator.axaml
+++ b/EmoTracker/Extensions/McpServer/McpStatusIndicator.axaml
@@ -1,0 +1,14 @@
+<UserControl x:Class="EmoTracker.Extensions.McpServer.McpStatusIndicator"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ToolTip.Tip>
+        <TextBlock Text="{Binding StatusText, StringFormat='MCP: {0}'}" />
+    </ToolTip.Tip>
+    <Ellipse Width="10" Height="10" StrokeThickness="0">
+        <Ellipse.Styles>
+            <Style Selector="Ellipse">
+                <Setter Property="Fill" Value="#888888" />
+            </Style>
+        </Ellipse.Styles>
+    </Ellipse>
+</UserControl>

--- a/EmoTracker/Extensions/McpServer/McpStatusIndicator.axaml.cs
+++ b/EmoTracker/Extensions/McpServer/McpStatusIndicator.axaml.cs
@@ -1,0 +1,87 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+using System;
+using System.ComponentModel;
+
+namespace EmoTracker.Extensions.McpServer
+{
+    public partial class McpStatusIndicator : UserControl
+    {
+        static readonly IBrush ActiveBrush = new SolidColorBrush(Color.Parse("#4CAF50"));
+        static readonly IBrush InactiveBrush = new SolidColorBrush(Color.Parse("#888888"));
+
+        public McpStatusIndicator()
+        {
+            InitializeComponent();
+            DataContextChanged += OnDataContextChanged;
+        }
+
+        private McpServerExtension _extension;
+
+        private void OnDataContextChanged(object sender, EventArgs e)
+        {
+            if (_extension != null)
+                _extension.PropertyChanged -= Extension_PropertyChanged;
+
+            _extension = DataContext as McpServerExtension;
+
+            if (_extension != null)
+                _extension.PropertyChanged += Extension_PropertyChanged;
+
+            UpdateIndicator();
+        }
+
+        private void Extension_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(McpServerExtension.Active))
+                UpdateIndicator();
+        }
+
+        private void UpdateIndicator()
+        {
+            var ellipse = this.FindControl<Ellipse>("PART_Indicator");
+            if (ellipse == null)
+            {
+                // Fall back: find the first Ellipse in the visual tree
+                ellipse = this.GetVisualDescendant<Ellipse>();
+            }
+            if (ellipse != null && _extension != null)
+                ellipse.Fill = _extension.Active ? ActiveBrush : InactiveBrush;
+        }
+    }
+
+    internal static class VisualExtensions
+    {
+        public static T GetVisualDescendant<T>(this Avalonia.Visual visual) where T : class
+        {
+            if (visual is Avalonia.Controls.Panel panel)
+            {
+                foreach (var child in panel.Children)
+                {
+                    if (child is T match)
+                        return match;
+                    if (child is Avalonia.Visual v)
+                    {
+                        var result = GetVisualDescendant<T>(v);
+                        if (result != null) return result;
+                    }
+                }
+            }
+            else if (visual is Avalonia.Controls.Decorator decorator && decorator.Child != null)
+            {
+                if (decorator.Child is T match)
+                    return match;
+                if (decorator.Child is Avalonia.Visual v)
+                    return GetVisualDescendant<T>(v);
+            }
+            else if (visual is ContentControl cc && cc.Content is Avalonia.Visual cv)
+            {
+                if (cv is T match)
+                    return match;
+                return GetVisualDescendant<T>(cv);
+            }
+            return null;
+        }
+    }
+}

--- a/EmoTracker/Extensions/McpServer/Tools/ApplicationControlTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/ApplicationControlTools.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using EmoTracker.Data;
 using EmoTracker.Data.Core.Transactions;
+using EmoTracker.Data.Core.Transactions.Processors;
 using EmoTracker.Data.Items;
 using EmoTracker.Data.Locations;
 using EmoTracker.Data.Packages;
@@ -218,6 +219,29 @@ namespace EmoTracker.Extensions.McpServer.Tools
 
                     window.Close();
                     return JsonSerializer.Serialize(new { success = true });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "undo")]
+        [Description("Undo the last tracker action (equivalent to Ctrl+Z)")]
+        public static async Task<string> Undo()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    if (TransactionProcessor.Current is IUndoableTransactionProcessor undo)
+                    {
+                        undo.Undo();
+                        return JsonSerializer.Serialize(new { success = true });
+                    }
+
+                    return JsonSerializer.Serialize(new { success = false, error = "Undo not available" });
                 }
                 catch (Exception ex)
                 {

--- a/EmoTracker/Extensions/McpServer/Tools/ApplicationControlTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/ApplicationControlTools.cs
@@ -1,0 +1,258 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
+using EmoTracker.Data;
+using EmoTracker.Data.Core.Transactions;
+using EmoTracker.Data.Items;
+using EmoTracker.Data.Locations;
+using EmoTracker.Data.Packages;
+using ModelContextProtocol.Server;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer.Tools
+{
+    [McpServerToolType]
+    public class ApplicationControlTools
+    {
+        [McpServerTool(Name = "list_packs")]
+        [Description("List all available game packs that can be loaded")]
+        public static async Task<string> ListPacks()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var packages = PackageManager.Instance.AvailablePackages;
+                var result = new List<object>();
+
+                foreach (var entry in packages)
+                {
+                    result.Add(new
+                    {
+                        name = entry.Name,
+                        uniqueId = entry.UID,
+                        game = entry.Game,
+                        author = entry.Author,
+                        version = entry.Version?.ToString(),
+                        installed = entry.ExistingPackage != null
+                    });
+                }
+
+                return JsonSerializer.Serialize(result);
+            });
+        }
+
+        [McpServerTool(Name = "load_pack")]
+        [Description("Load a game pack by its unique ID. Optionally specify a variant.")]
+        public static async Task<string> LoadPack(
+            [Description("The unique ID of the pack to load")] string uniqueId,
+            [Description("Optional variant unique ID")] string variant = null)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var packages = PackageManager.Instance.AvailablePackages;
+                    PackageRepositoryEntry found = null;
+
+                    foreach (var entry in packages)
+                    {
+                        if (entry.UID != null &&
+                            entry.UID.Equals(uniqueId, StringComparison.OrdinalIgnoreCase))
+                        {
+                            found = entry;
+                            break;
+                        }
+                    }
+
+                    if (found?.ExistingPackage == null)
+                        return JsonSerializer.Serialize(new { success = false, error = "Pack not found or not installed" });
+
+                    var pack = found.ExistingPackage;
+
+                    if (!string.IsNullOrEmpty(variant))
+                    {
+                        var v = pack.FindVariant(variant);
+                        if (v != null)
+                        {
+                            Tracker.Instance.ActiveGamePackageVariant = v;
+                            return JsonSerializer.Serialize(new { success = true, variant = v.DisplayName });
+                        }
+                        return JsonSerializer.Serialize(new { success = false, error = "Variant not found" });
+                    }
+
+                    Tracker.Instance.ActiveGamePackage = pack;
+                    return JsonSerializer.Serialize(new { success = true });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "toggle_item")]
+        [Description("Toggle a tracker item by name (simulates left-click)")]
+        public static async Task<string> ToggleItem([Description("The item name")] string name)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var item = FindItemByName(name);
+                    if (item == null)
+                        return JsonSerializer.Serialize(new { success = false, error = "Item not found" });
+
+                    item.OnLeftClick();
+                    return SerializeItemState(item);
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "right_click_item")]
+        [Description("Simulate right-click on a tracker item by name")]
+        public static async Task<string> RightClickItem([Description("The item name")] string name)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var item = FindItemByName(name);
+                    if (item == null)
+                        return JsonSerializer.Serialize(new { success = false, error = "Item not found" });
+
+                    item.OnRightClick();
+                    return SerializeItemState(item);
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "reset_tracker")]
+        [Description("Reset all tracker state to initial values")]
+        public static async Task<string> ResetTracker()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    ApplicationModel.Instance.ResetUserDataCommand?.Execute(null);
+                    return JsonSerializer.Serialize(new { success = true });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "clear_location")]
+        [Description("Clear a location by name, simulating a right-click on its map square. Calls FullClearAllPossible() within a transaction.")]
+        public static async Task<string> ClearLocation([Description("The location name to clear")] string name)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var locations = LocationDatabase.Instance.AllLocations;
+                    if (locations == null)
+                        return JsonSerializer.Serialize(new { success = false, error = "No locations loaded" });
+
+                    EmoTracker.Data.Locations.Location found = null;
+                    foreach (var loc in locations)
+                    {
+                        if (loc?.Name != null &&
+                            loc.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            found = loc;
+                            break;
+                        }
+                    }
+
+                    if (found == null)
+                        return JsonSerializer.Serialize(new { success = false, error = $"Location '{name}' not found" });
+
+                    using (TransactionProcessor.Current.OpenTransaction())
+                    {
+                        found.FullClearAllPossible();
+                        found.ModifiedByUser = true;
+                    }
+
+                    return JsonSerializer.Serialize(new
+                    {
+                        success = true,
+                        name = found.Name,
+                        accessibility = found.AccessibilityLevel.ToString()
+                    });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "shutdown")]
+        [Description("Trigger a normal shutdown of the application by closing the main window")]
+        public static async Task<string> Shutdown()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var lifetime = Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
+                    var window = lifetime?.MainWindow;
+                    if (window == null)
+                        return JsonSerializer.Serialize(new { success = false, error = "Main window not found" });
+
+                    window.Close();
+                    return JsonSerializer.Serialize(new { success = true });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        private static ITrackableItem FindItemByName(string name)
+        {
+            foreach (var item in ItemDatabase.Instance.Items)
+            {
+                if (item?.Name != null &&
+                    item.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                    return item;
+            }
+            return null;
+        }
+
+        private static string SerializeItemState(ITrackableItem item)
+        {
+            var state = new Dictionary<string, object>
+            {
+                ["success"] = true,
+                ["name"] = item.Name,
+                ["badgeText"] = item.BadgeText
+            };
+
+            if (item is ToggleItem toggle)
+                state["active"] = toggle.Active;
+            else if (item is ConsumableItem consumable)
+                state["acquiredCount"] = consumable.AcquiredCount;
+            else if (item is ProgressiveItem progressive)
+                state["currentStage"] = progressive.CurrentStage;
+            return JsonSerializer.Serialize(state);
+        }
+    }
+}

--- a/EmoTracker/Extensions/McpServer/Tools/ExtensionTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/ExtensionTools.cs
@@ -1,0 +1,90 @@
+using Avalonia.Threading;
+using EmoTracker.Data.AutoTracking;
+using EmoTracker.Extensions;
+using ModelContextProtocol.Server;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer.Tools
+{
+    [McpServerToolType]
+    public class ExtensionTools
+    {
+        [McpServerTool(Name = "list_extensions")]
+        [Description("List all registered extensions with their status")]
+        public static async Task<string> ListExtensions()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var extensions = ExtensionManager.Instance.Extensions;
+                var result = new List<object>();
+
+                foreach (var ext in extensions)
+                {
+                    var entry = new Dictionary<string, object>
+                    {
+                        ["name"] = ext.Name,
+                        ["uid"] = ext.UID,
+                        ["priority"] = ext.Priority
+                    };
+
+                    if (ext is McpServer.McpServerExtension mcpExt)
+                    {
+                        entry["active"] = mcpExt.Active;
+                        entry["statusText"] = mcpExt.StatusText;
+                    }
+
+                    result.Add(entry);
+                }
+
+                return JsonSerializer.Serialize(result);
+            });
+        }
+
+        [McpServerTool(Name = "get_autotracker_status")]
+        [Description("Get auto-tracker connection status, available providers, and devices")]
+        public static async Task<string> GetAutoTrackerStatus()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var registry = AutoTrackingProviderRegistry.Instance;
+                    var providers = new List<object>();
+
+                    foreach (var provider in registry.Providers)
+                    {
+                        var devices = new List<object>();
+                        foreach (var device in provider.AvailableDevices)
+                        {
+                            devices.Add(new
+                            {
+                                name = device.ToString()
+                            });
+                        }
+
+                        providers.Add(new
+                        {
+                            uid = provider.UID,
+                            displayName = provider.DisplayName,
+                            isConnected = provider.IsConnected,
+                            supportedPlatforms = provider.SupportedPlatforms?.Select(p => p.ToString()).ToArray(),
+                            defaultDevice = provider.DefaultDevice?.ToString(),
+                            availableDevices = devices
+                        });
+                    }
+
+                    return JsonSerializer.Serialize(new { providers });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { error = ex.Message });
+                }
+            });
+        }
+    }
+}

--- a/EmoTracker/Extensions/McpServer/Tools/LocationTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/LocationTools.cs
@@ -1,0 +1,350 @@
+using Avalonia.Threading;
+using EmoTracker.Data;
+using EmoTracker.Data.Core.Transactions;
+using EmoTracker.Data.Locations;
+using ModelContextProtocol.Server;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer.Tools
+{
+    [McpServerToolType]
+    public class LocationTools
+    {
+        [McpServerTool(Name = "get_location")]
+        [Description("Get full details for a location by name, including sections, children, pinned state, badges, and notes")]
+        public static async Task<string> GetLocation([Description("The location name")] string name)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var loc = LocationDatabase.Instance.FindLocation(name);
+                if (loc == null)
+                    return JsonSerializer.Serialize(new { found = false });
+
+                var sections = new List<object>();
+                foreach (var section in loc.Sections)
+                {
+                    sections.Add(new
+                    {
+                        name = section.Name,
+                        shortName = section.ShortName,
+                        chestCount = section.ChestCount,
+                        availableChestCount = section.AvailableChestCount,
+                        accessibility = section.AccessibilityLevel.ToString(),
+                        gateAccessibility = section.GateAccessibilityLevel.ToString(),
+                        visible = section.Visible,
+                        hasUnclaimedItems = section.HasUnclaimedItems,
+                        clearAsGroup = section.ClearAsGroup,
+                        captureItem = section.CaptureItem,
+                        hostedItemCode = section.HostedItemCode,
+                        capturedItem = section.CapturedItem?.Name
+                    });
+                }
+
+                var children = new List<object>();
+                foreach (var child in loc.Children)
+                {
+                    children.Add(new
+                    {
+                        name = child.Name,
+                        accessibility = child.AccessibilityLevel.ToString(),
+                        availableItemCount = child.AvailableItemCount
+                    });
+                }
+
+                var notes = new List<object>();
+                if (loc.NoteTakingSite != null)
+                {
+                    foreach (var note in loc.NoteTakingSite.Notes)
+                    {
+                        if (note is Data.Notes.MarkdownTextNote mdNote)
+                        {
+                            notes.Add(new
+                            {
+                                type = note.GetType().Name,
+                                text = mdNote.MarkdownSource
+                            });
+                        }
+                        else
+                        {
+                            notes.Add(new { type = note.GetType().Name });
+                        }
+                    }
+                }
+
+                return JsonSerializer.Serialize(new
+                {
+                    found = true,
+                    name = loc.Name,
+                    shortName = loc.ShortName,
+                    accessibility = loc.AccessibilityLevel.ToString(),
+                    baseAccessibility = loc.BaseAccessibilityLevel.ToString(),
+                    pinned = loc.Pinned,
+                    color = loc.Color,
+                    hasLocalItems = loc.HasLocalItems,
+                    hasAvailableItems = loc.HasAvailableItems,
+                    availableItemCount = loc.AvailableItemCount,
+                    modifiedByUser = loc.ModifiedByUser,
+                    parent = loc.Parent?.Name,
+                    sections,
+                    children,
+                    notes
+                });
+            });
+        }
+
+        [McpServerTool(Name = "pin_location")]
+        [Description("Pin a location by name to the pinned locations list")]
+        public static async Task<string> PinLocation([Description("The location name")] string name)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var loc = LocationDatabase.Instance.FindLocation(name);
+                    if (loc == null)
+                        return JsonSerializer.Serialize(new { success = false, error = $"Location '{name}' not found" });
+
+                    LocationDatabase.Instance.PinLocation(loc);
+                    return JsonSerializer.Serialize(new { success = true, name = loc.Name, pinned = loc.Pinned });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "unpin_location")]
+        [Description("Unpin a location by name from the pinned locations list")]
+        public static async Task<string> UnpinLocation([Description("The location name")] string name)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var loc = LocationDatabase.Instance.FindLocation(name);
+                    if (loc == null)
+                        return JsonSerializer.Serialize(new { success = false, error = $"Location '{name}' not found" });
+
+                    LocationDatabase.Instance.UnpinLocation(loc);
+                    return JsonSerializer.Serialize(new { success = true, name = loc.Name, pinned = loc.Pinned });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "list_pinned_locations")]
+        [Description("List all currently pinned locations")]
+        public static async Task<string> ListPinnedLocations()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var pinned = LocationDatabase.Instance.PinnedLocations;
+                var result = new List<object>();
+                foreach (var loc in pinned)
+                {
+                    result.Add(new
+                    {
+                        name = loc.Name,
+                        accessibility = loc.AccessibilityLevel.ToString(),
+                        availableItemCount = loc.AvailableItemCount
+                    });
+                }
+                return JsonSerializer.Serialize(result);
+            });
+        }
+
+        [McpServerTool(Name = "clear_section")]
+        [Description("Clear a specific section within a location by decrementing its available chest count")]
+        public static async Task<string> ClearSection(
+            [Description("The location name")] string locationName,
+            [Description("The section name")] string sectionName)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var loc = LocationDatabase.Instance.FindLocation(locationName);
+                    if (loc == null)
+                        return JsonSerializer.Serialize(new { success = false, error = $"Location '{locationName}' not found" });
+
+                    var section = loc.FindSection(sectionName);
+                    if (section == null)
+                        return JsonSerializer.Serialize(new { success = false, error = $"Section '{sectionName}' not found in '{locationName}'" });
+
+                    using (TransactionProcessor.Current.OpenTransaction())
+                    {
+                        if (section.AvailableChestCount > 0)
+                            section.AvailableChestCount = 0;
+                        loc.ModifiedByUser = true;
+                    }
+
+                    return JsonSerializer.Serialize(new
+                    {
+                        success = true,
+                        location = loc.Name,
+                        section = section.Name,
+                        chestCount = section.ChestCount,
+                        availableChestCount = section.AvailableChestCount,
+                        accessibility = section.AccessibilityLevel.ToString()
+                    });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "unclear_location")]
+        [Description("Undo a location clear by restoring all section chest counts to their maximums")]
+        public static async Task<string> UnclearLocation([Description("The location name")] string name)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var loc = LocationDatabase.Instance.FindLocation(name);
+                    if (loc == null)
+                        return JsonSerializer.Serialize(new { success = false, error = $"Location '{name}' not found" });
+
+                    using (TransactionProcessor.Current.OpenTransaction())
+                    {
+                        foreach (var section in loc.Sections)
+                        {
+                            section.AvailableChestCount = section.ChestCount;
+                        }
+                        loc.ModifiedByUser = true;
+                    }
+
+                    return JsonSerializer.Serialize(new
+                    {
+                        success = true,
+                        name = loc.Name,
+                        accessibility = loc.AccessibilityLevel.ToString()
+                    });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "check_accessibility")]
+        [Description("Check a location's computed accessibility level and per-section breakdown")]
+        public static async Task<string> CheckAccessibility([Description("The location name")] string name)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var loc = LocationDatabase.Instance.FindLocation(name);
+                if (loc == null)
+                    return JsonSerializer.Serialize(new { found = false, error = $"Location '{name}' not found" });
+
+                var sections = new List<object>();
+                foreach (var section in loc.Sections)
+                {
+                    sections.Add(new
+                    {
+                        name = section.Name,
+                        accessibility = section.AccessibilityLevel.ToString(),
+                        gateAccessibility = section.GateAccessibilityLevel.ToString(),
+                        visible = section.Visible,
+                        chestCount = section.ChestCount,
+                        availableChestCount = section.AvailableChestCount
+                    });
+                }
+
+                return JsonSerializer.Serialize(new
+                {
+                    found = true,
+                    name = loc.Name,
+                    accessibility = loc.AccessibilityLevel.ToString(),
+                    baseAccessibility = loc.BaseAccessibilityLevel.ToString(),
+                    hasAvailableItems = loc.HasAvailableItems,
+                    availableItemCount = loc.AvailableItemCount,
+                    sections
+                });
+            });
+        }
+
+        [McpServerTool(Name = "list_accessible_locations")]
+        [Description("List locations filtered by accessibility level. Valid levels: None, Partial, Inspect, SequenceBreak, Normal, Cleared")]
+        public static async Task<string> ListAccessibleLocations(
+            [Description("Filter to this accessibility level (e.g. 'Normal', 'Partial'). If omitted, lists all non-None locations.")] string level = null)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var locations = LocationDatabase.Instance.AllLocations;
+                if (locations == null)
+                    return JsonSerializer.Serialize(Array.Empty<object>());
+
+                AccessibilityLevel? filterLevel = null;
+                if (!string.IsNullOrEmpty(level))
+                {
+                    if (Enum.TryParse<AccessibilityLevel>(level, true, out var parsed))
+                        filterLevel = parsed;
+                    else
+                        return JsonSerializer.Serialize(new { error = $"Unknown accessibility level: {level}" });
+                }
+
+                var result = new List<object>();
+                foreach (var loc in locations)
+                {
+                    if (loc == null) continue;
+
+                    if (filterLevel.HasValue)
+                    {
+                        if (loc.AccessibilityLevel != filterLevel.Value)
+                            continue;
+                    }
+                    else
+                    {
+                        if (loc.AccessibilityLevel == AccessibilityLevel.None)
+                            continue;
+                    }
+
+                    result.Add(new
+                    {
+                        name = loc.Name,
+                        accessibility = loc.AccessibilityLevel.ToString(),
+                        availableItemCount = loc.AvailableItemCount
+                    });
+                }
+
+                return JsonSerializer.Serialize(result);
+            });
+        }
+
+        [McpServerTool(Name = "check_code")]
+        [Description("Query how many providers satisfy a given code and at what accessibility level. Use '@location/section' for location codes.")]
+        public static async Task<string> CheckCode([Description("The code to check (e.g. 'bow', 'hookshot', '@Eastern Palace/Dungeon')")] string code)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var count = Tracker.Instance.ProviderCountForCode(code, out AccessibilityLevel maxAccessibility);
+                    return JsonSerializer.Serialize(new
+                    {
+                        code,
+                        providerCount = count,
+                        maxAccessibility = maxAccessibility.ToString()
+                    });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { error = ex.Message });
+                }
+            });
+        }
+    }
+}

--- a/EmoTracker/Extensions/McpServer/Tools/LuaTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/LuaTools.cs
@@ -1,0 +1,128 @@
+using Avalonia.Threading;
+using EmoTracker.Data;
+using ModelContextProtocol.Server;
+using NLua;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer.Tools
+{
+    [McpServerToolType]
+    public class LuaTools
+    {
+        [McpServerTool(Name = "get_console_log")]
+        [Description("Read the developer console log output. Returns the most recent log lines.")]
+        public static async Task<string> GetConsoleLog(
+            [Description("Number of most recent lines to return")] int lastN = 50)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var logOutput = ScriptManager.Instance.LogOutput;
+                if (logOutput == null)
+                    return JsonSerializer.Serialize(Array.Empty<object>());
+
+                var lines = logOutput.Cast<ScriptManager.LogLine>().ToList();
+                if (lastN > 0 && lines.Count > lastN)
+                    lines = lines.Skip(lines.Count - lastN).ToList();
+
+                var result = lines.Select(l => new
+                {
+                    text = l.Text,
+                    color = l.Color
+                }).ToArray();
+
+                return JsonSerializer.Serialize(result);
+            });
+        }
+
+        [McpServerTool(Name = "execute_lua")]
+        [Description("Execute Lua code in the pack's Lua scripting environment. Returns the results or error.")]
+        public static async Task<string> ExecuteLua(
+            [Description("The Lua code to execute")] string code)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    if (!ScriptManager.Instance.IsLuaLoaded)
+                        return JsonSerializer.Serialize(new { error = "No Lua environment loaded (no pack active)" });
+
+                    var results = ScriptManager.Instance.ExecuteLuaString(code);
+                    if (results == null || results.Length == 0)
+                        return JsonSerializer.Serialize(new { results = Array.Empty<string>() });
+
+                    var stringResults = results.Select(r => SerializeLuaValue(r)).ToArray();
+                    return JsonSerializer.Serialize(new { results = stringResults });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "get_lua_global")]
+        [Description("Read a Lua global variable's value by name")]
+        public static async Task<string> GetLuaGlobal(
+            [Description("The Lua global variable name")] string name)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    if (!ScriptManager.Instance.IsLuaLoaded)
+                        return JsonSerializer.Serialize(new { error = "No Lua environment loaded (no pack active)" });
+
+                    var value = ScriptManager.Instance.GetLuaGlobal(name);
+                    return JsonSerializer.Serialize(new
+                    {
+                        name,
+                        value = SerializeLuaValue(value),
+                        type = GetLuaTypeName(value)
+                    });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { error = ex.Message });
+                }
+            });
+        }
+
+        private static string SerializeLuaValue(object value)
+        {
+            if (value == null)
+                return "nil";
+            if (value is LuaTable table)
+            {
+                var entries = new List<string>();
+                var keys = table.Keys;
+                foreach (var key in keys)
+                {
+                    var val = table[key];
+                    entries.Add($"{key} = {SerializeLuaValue(val)}");
+                }
+                return "{" + string.Join(", ", entries) + "}";
+            }
+            if (value is LuaFunction)
+                return "<function>";
+            if (value is bool b)
+                return b ? "true" : "false";
+            return value.ToString();
+        }
+
+        private static string GetLuaTypeName(object value)
+        {
+            if (value == null) return "nil";
+            if (value is bool) return "boolean";
+            if (value is string) return "string";
+            if (value is double || value is long || value is int || value is float) return "number";
+            if (value is LuaTable) return "table";
+            if (value is LuaFunction) return "function";
+            return value.GetType().Name;
+        }
+    }
+}

--- a/EmoTracker/Extensions/McpServer/Tools/NoteTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/NoteTools.cs
@@ -1,0 +1,117 @@
+using Avalonia.Threading;
+using EmoTracker.Data;
+using EmoTracker.Data.Notes;
+using ModelContextProtocol.Server;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer.Tools
+{
+    [McpServerToolType]
+    public class NoteTools
+    {
+        [McpServerTool(Name = "add_note")]
+        [Description("Add a text note to a location")]
+        public static async Task<string> AddNote(
+            [Description("The location name")] string locationName,
+            [Description("The note text (supports markdown)")] string text)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var loc = LocationDatabase.Instance.FindLocation(locationName);
+                    if (loc == null)
+                        return JsonSerializer.Serialize(new { success = false, error = $"Location '{locationName}' not found" });
+
+                    if (loc.NoteTakingSite == null)
+                        return JsonSerializer.Serialize(new { success = false, error = "Note taking not available for this location" });
+
+                    var note = new MarkdownTextWithItemsNote();
+                    note.MarkdownSource = text;
+                    loc.NoteTakingSite.AddNote(note);
+
+                    return JsonSerializer.Serialize(new { success = true, location = loc.Name });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "get_notes")]
+        [Description("Get all notes for a location")]
+        public static async Task<string> GetNotes([Description("The location name")] string locationName)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var loc = LocationDatabase.Instance.FindLocation(locationName);
+                if (loc == null)
+                    return JsonSerializer.Serialize(new { found = false, error = $"Location '{locationName}' not found" });
+
+                if (loc.NoteTakingSite == null)
+                    return JsonSerializer.Serialize(new { found = true, notes = Array.Empty<object>() });
+
+                var notes = new List<object>();
+                foreach (var note in loc.NoteTakingSite.Notes)
+                {
+                    if (note is MarkdownTextNote mdNote)
+                    {
+                        var items = new List<string>();
+                        if (note is MarkdownTextWithItemsNote itemNote)
+                        {
+                            foreach (var item in itemNote.Items)
+                            {
+                                if (item != null)
+                                    items.Add(item.Name);
+                            }
+                        }
+
+                        notes.Add(new
+                        {
+                            type = note.GetType().Name,
+                            text = mdNote.MarkdownSource,
+                            items,
+                            readOnly = note.ReadOnly
+                        });
+                    }
+                    else
+                    {
+                        notes.Add(new { type = note.GetType().Name, readOnly = note.ReadOnly });
+                    }
+                }
+
+                return JsonSerializer.Serialize(new { found = true, location = loc.Name, notes });
+            });
+        }
+
+        [McpServerTool(Name = "clear_notes")]
+        [Description("Clear all notes from a location")]
+        public static async Task<string> ClearNotes([Description("The location name")] string locationName)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var loc = LocationDatabase.Instance.FindLocation(locationName);
+                    if (loc == null)
+                        return JsonSerializer.Serialize(new { success = false, error = $"Location '{locationName}' not found" });
+
+                    if (loc.NoteTakingSite == null)
+                        return JsonSerializer.Serialize(new { success = false, error = "Note taking not available for this location" });
+
+                    loc.NoteTakingSite.Clear();
+                    return JsonSerializer.Serialize(new { success = true, location = loc.Name });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+    }
+}

--- a/EmoTracker/Extensions/McpServer/Tools/PackDataTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/PackDataTools.cs
@@ -1,5 +1,6 @@
 using Avalonia.Threading;
 using EmoTracker.Data;
+using EmoTracker.Data.Core.Transactions;
 using EmoTracker.Data.Items;
 using EmoTracker.Data.Locations;
 using ModelContextProtocol.Server;
@@ -183,6 +184,186 @@ namespace EmoTracker.Extensions.McpServer.Tools
 
                 return JsonSerializer.Serialize(new { found = false });
             });
+        }
+
+        [McpServerTool(Name = "find_item_by_code")]
+        [Description("Find a tracked item by its internal code (e.g. 'bow', 'hookshot') rather than display name")]
+        public static async Task<string> FindItemByCode([Description("The item code to search for")] string code)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var item = ItemDatabase.Instance.FindObjectForCode(code) as ITrackableItem;
+                if (item == null)
+                    return JsonSerializer.Serialize(new { found = false });
+
+                return JsonSerializer.Serialize(SerializeItemDetails(item, true));
+            });
+        }
+
+        [McpServerTool(Name = "get_item_details")]
+        [Description("Get extended details for a tracked item by name, including codes, type info, and capturable status")]
+        public static async Task<string> GetItemDetails([Description("The exact item name")] string name)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var items = ItemDatabase.Instance.Items;
+                if (items == null)
+                    return JsonSerializer.Serialize(new { found = false });
+
+                foreach (var item in items)
+                {
+                    if (item?.Name != null &&
+                        item.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return JsonSerializer.Serialize(SerializeItemDetails(item, true));
+                    }
+                }
+
+                return JsonSerializer.Serialize(new { found = false });
+            });
+        }
+
+        [McpServerTool(Name = "set_item_state")]
+        [Description("Directly set an item's state: active flag for toggles, stage index for progressive, count for consumable")]
+        public static async Task<string> SetItemState(
+            [Description("The item name")] string name,
+            [Description("For toggle items: 'true' or 'false'. For progressive: stage index (0-based). For consumable: acquired count.")] string value)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    ITrackableItem item = null;
+                    foreach (var i in ItemDatabase.Instance.Items)
+                    {
+                        if (i?.Name != null && i.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            item = i;
+                            break;
+                        }
+                    }
+
+                    if (item == null)
+                        return JsonSerializer.Serialize(new { success = false, error = "Item not found" });
+
+                    using (TransactionProcessor.Current.OpenTransaction())
+                    {
+                        if (item is ToggleItem toggle)
+                        {
+                            if (!bool.TryParse(value, out var boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false for toggle item" });
+                            toggle.Active = boolVal;
+                        }
+                        else if (item is ProgressiveItem progressive)
+                        {
+                            if (!int.TryParse(value, out var stage))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected integer stage index" });
+                            progressive.CurrentStage = stage;
+                        }
+                        else if (item is ConsumableItem consumable)
+                        {
+                            if (!int.TryParse(value, out var count))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected integer count" });
+                            consumable.AcquiredCount = count;
+                        }
+                        else
+                        {
+                            return JsonSerializer.Serialize(new { success = false, error = $"Cannot set state on item type: {item.GetType().Name}" });
+                        }
+                    }
+
+                    return JsonSerializer.Serialize(SerializeItemDetails(item, false));
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "batch_toggle_items")]
+        [Description("Toggle multiple items by name in a single transaction (simulates left-click on each)")]
+        public static async Task<string> BatchToggleItems(
+            [Description("Comma-separated list of item names to toggle")] string names)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var nameList = names.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                    var results = new List<object>();
+
+                    using (TransactionProcessor.Current.OpenTransaction())
+                    {
+                        foreach (var name in nameList)
+                        {
+                            ITrackableItem found = null;
+                            foreach (var item in ItemDatabase.Instance.Items)
+                            {
+                                if (item?.Name != null && item.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    found = item;
+                                    break;
+                                }
+                            }
+
+                            if (found != null)
+                            {
+                                found.OnLeftClick();
+                                results.Add(new { name = found.Name, success = true, badgeText = found.BadgeText });
+                            }
+                            else
+                            {
+                                results.Add(new { name, success = false, error = "Item not found" });
+                            }
+                        }
+                    }
+
+                    return JsonSerializer.Serialize(results);
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { error = ex.Message });
+                }
+            });
+        }
+
+        private static Dictionary<string, object> SerializeItemDetails(ITrackableItem item, bool includeFound)
+        {
+            var entry = new Dictionary<string, object>();
+
+            if (includeFound)
+                entry["found"] = true;
+            else
+                entry["success"] = true;
+
+            entry["name"] = item.Name;
+            entry["type"] = item.GetType().Name;
+            entry["badgeText"] = item.BadgeText;
+            entry["capturable"] = item.Capturable;
+            entry["ignoreUserInput"] = item.IgnoreUserInput;
+
+            if (item is ToggleItem toggle)
+            {
+                entry["active"] = toggle.Active;
+                entry["loop"] = toggle.Loop;
+            }
+            else if (item is ConsumableItem consumable)
+            {
+                entry["acquiredCount"] = consumable.AcquiredCount;
+                entry["consumedCount"] = consumable.ConsumedCount;
+                entry["availableCount"] = consumable.AvailableCount;
+                entry["minCount"] = consumable.MinCount;
+                entry["maxCount"] = consumable.MaxCount;
+                entry["countIncrement"] = consumable.CountIncrement;
+            }
+            else if (item is ProgressiveItem progressive)
+            {
+                entry["currentStage"] = progressive.CurrentStage;
+                entry["loop"] = progressive.Loop;
+            }
+
+            return entry;
         }
     }
 }

--- a/EmoTracker/Extensions/McpServer/Tools/PackDataTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/PackDataTools.cs
@@ -1,0 +1,188 @@
+using Avalonia.Threading;
+using EmoTracker.Data;
+using EmoTracker.Data.Items;
+using EmoTracker.Data.Locations;
+using ModelContextProtocol.Server;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer.Tools
+{
+    [McpServerToolType]
+    public class PackDataTools
+    {
+        [McpServerTool(Name = "get_loaded_pack")]
+        [Description("Get information about the currently loaded game pack")]
+        public static async Task<string> GetLoadedPack()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var pack = Tracker.Instance.ActiveGamePackage;
+                if (pack == null)
+                    return JsonSerializer.Serialize(new { loaded = false });
+
+                var variant = Tracker.Instance.ActiveGamePackageVariant;
+                var variants = pack.AvailableVariants?.Select(v => new
+                {
+                    uniqueId = v.UniqueID,
+                    displayName = v.DisplayName
+                }).ToArray();
+
+                return JsonSerializer.Serialize(new
+                {
+                    loaded = true,
+                    displayName = pack.DisplayName,
+                    uniqueId = pack.UniqueID,
+                    game = pack.Game,
+                    gameVariant = pack.GameVariant,
+                    author = pack.Author,
+                    version = pack.Version?.ToString(),
+                    platform = pack.Platform.ToString(),
+                    activeVariant = variant != null ? new
+                    {
+                        uniqueId = variant.UniqueID,
+                        displayName = variant.DisplayName
+                    } : null,
+                    availableVariants = variants
+                });
+            });
+        }
+
+        [McpServerTool(Name = "list_items")]
+        [Description("List all tracked items with their current state. Optionally filter by name substring.")]
+        public static async Task<string> ListItems([Description("Optional name substring filter")] string filter = null)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var items = ItemDatabase.Instance.Items;
+                if (items == null)
+                    return JsonSerializer.Serialize(Array.Empty<object>());
+
+                var result = new List<object>();
+                foreach (var item in items)
+                {
+                    if (item == null) continue;
+                    if (!string.IsNullOrEmpty(filter) &&
+                        (item.Name == null || !item.Name.Contains(filter, StringComparison.OrdinalIgnoreCase)))
+                        continue;
+
+                    var entry = new Dictionary<string, object>
+                    {
+                        ["name"] = item.Name,
+                        ["badgeText"] = item.BadgeText,
+                        ["type"] = item.GetType().Name
+                    };
+
+                    if (item is ToggleItem toggle)
+                    {
+                        entry["active"] = toggle.Active;
+                    }
+                    else if (item is ConsumableItem consumable)
+                    {
+                        entry["acquiredCount"] = consumable.AcquiredCount;
+                        entry["maxCount"] = consumable.MaxCount;
+                    }
+                    else if (item is ProgressiveItem progressive)
+                    {
+                        entry["currentStage"] = progressive.CurrentStage;
+                    }
+
+                    result.Add(entry);
+                }
+
+                return JsonSerializer.Serialize(result);
+            });
+        }
+
+        [McpServerTool(Name = "list_locations")]
+        [Description("List all locations with accessibility status. Optionally filter by name substring.")]
+        public static async Task<string> ListLocations([Description("Optional name substring filter")] string filter = null)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var locations = LocationDatabase.Instance.AllLocations;
+                if (locations == null)
+                    return JsonSerializer.Serialize(Array.Empty<object>());
+
+                var result = new List<object>();
+                foreach (var loc in locations)
+                {
+                    if (loc == null) continue;
+                    if (!string.IsNullOrEmpty(filter) &&
+                        (loc.Name == null || !loc.Name.Contains(filter, StringComparison.OrdinalIgnoreCase)))
+                        continue;
+
+                    var sections = new List<object>();
+                    foreach (var section in loc.Sections)
+                    {
+                        sections.Add(new
+                        {
+                            name = section.Name,
+                            chestCount = section.ChestCount,
+                            availableChestCount = section.AvailableChestCount,
+                            accessibility = section.AccessibilityLevel.ToString()
+                        });
+                    }
+
+                    result.Add(new
+                    {
+                        name = loc.Name,
+                        accessibility = loc.AccessibilityLevel.ToString(),
+                        sections,
+                        childCount = loc.Children.Count()
+                    });
+                }
+
+                return JsonSerializer.Serialize(result);
+            });
+        }
+
+        [McpServerTool(Name = "get_item_by_name")]
+        [Description("Find a tracked item by exact name and return its details")]
+        public static async Task<string> GetItemByName([Description("The exact item name to search for")] string name)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var items = ItemDatabase.Instance.Items;
+                if (items == null)
+                    return JsonSerializer.Serialize(new { found = false });
+
+                foreach (var item in items)
+                {
+                    if (item?.Name != null &&
+                        item.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var entry = new Dictionary<string, object>
+                        {
+                            ["found"] = true,
+                            ["name"] = item.Name,
+                            ["type"] = item.GetType().Name,
+                            ["badgeText"] = item.BadgeText,
+                            ["capturable"] = item.Capturable
+                        };
+
+                        if (item is ToggleItem toggle)
+                            entry["active"] = toggle.Active;
+                        else if (item is ConsumableItem consumable)
+                        {
+                            entry["acquiredCount"] = consumable.AcquiredCount;
+                            entry["maxCount"] = consumable.MaxCount;
+                        }
+                        else if (item is ProgressiveItem progressive)
+                        {
+                            entry["currentStage"] = progressive.CurrentStage;
+                        }
+
+                        return JsonSerializer.Serialize(entry);
+                    }
+                }
+
+                return JsonSerializer.Serialize(new { found = false });
+            });
+        }
+    }
+}

--- a/EmoTracker/Extensions/McpServer/Tools/PackageTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/PackageTools.cs
@@ -1,0 +1,97 @@
+using Avalonia.Threading;
+using EmoTracker.Data;
+using ModelContextProtocol.Server;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer.Tools
+{
+    [McpServerToolType]
+    public class PackageTools
+    {
+        [McpServerTool(Name = "get_pack_files")]
+        [Description("List all files in the currently loaded game pack")]
+        public static async Task<string> GetPackFiles()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var pack = Tracker.Instance.ActiveGamePackage;
+                if (pack == null)
+                    return JsonSerializer.Serialize(new { error = "No pack loaded" });
+
+                var source = pack.Source;
+                if (source == null)
+                    return JsonSerializer.Serialize(new { error = "Pack source not available" });
+
+                var files = source.Files?.ToList() ?? new List<string>();
+                return JsonSerializer.Serialize(new
+                {
+                    packName = pack.DisplayName,
+                    fileCount = files.Count,
+                    files
+                });
+            });
+        }
+
+        [McpServerTool(Name = "get_pack_file_content")]
+        [Description("Read a text file from the currently loaded game pack (e.g. Lua scripts, JSON layouts)")]
+        public static async Task<string> GetPackFileContent(
+            [Description("Path of the file within the pack (e.g. 'scripts/init.lua', 'manifest.json')")] string path)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var pack = Tracker.Instance.ActiveGamePackage;
+                    if (pack == null)
+                        return JsonSerializer.Serialize(new { error = "No pack loaded" });
+
+                    using var stream = pack.Open(path);
+                    if (stream == null)
+                        return JsonSerializer.Serialize(new { error = $"File not found: {path}" });
+
+                    using var reader = new StreamReader(stream);
+                    var content = reader.ReadToEnd();
+
+                    return JsonSerializer.Serialize(new
+                    {
+                        path,
+                        size = content.Length,
+                        content
+                    });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "reload_pack")]
+        [Description("Reload the currently loaded pack (equivalent to pressing F5)")]
+        public static async Task<string> ReloadPack()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var pack = Tracker.Instance.ActiveGamePackage;
+                    if (pack == null)
+                        return JsonSerializer.Serialize(new { success = false, error = "No pack loaded" });
+
+                    Tracker.Instance.Reload();
+                    return JsonSerializer.Serialize(new { success = true, packName = pack.DisplayName });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+    }
+}

--- a/EmoTracker/Extensions/McpServer/Tools/SaveLoadTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/SaveLoadTools.cs
@@ -1,0 +1,109 @@
+using Avalonia.Threading;
+using EmoTracker.Core;
+using EmoTracker.Data;
+using ModelContextProtocol.Server;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer.Tools
+{
+    [McpServerToolType]
+    public class SaveLoadTools
+    {
+        [McpServerTool(Name = "save_progress")]
+        [Description("Save the current tracker state to a file. If no path is given, saves to the default saves directory.")]
+        public static async Task<string> SaveProgress(
+            [Description("File path to save to. If just a filename, saves to the default saves directory.")] string path)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    string savePath = path;
+                    if (!Path.IsPathRooted(savePath))
+                    {
+                        string savesDir = Path.Combine(UserDirectory.Path, "saves");
+                        Directory.CreateDirectory(savesDir);
+                        savePath = Path.Combine(savesDir, savePath);
+                    }
+
+                    if (!savePath.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                        savePath += ".json";
+
+                    bool result = Tracker.Instance.SaveProgress(savePath);
+                    return JsonSerializer.Serialize(new { success = result, path = savePath });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "load_progress")]
+        [Description("Load tracker state from a save file. If just a filename, loads from the default saves directory.")]
+        public static async Task<string> LoadProgress(
+            [Description("File path to load from")] string path)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    string loadPath = path;
+                    if (!Path.IsPathRooted(loadPath))
+                    {
+                        loadPath = Path.Combine(UserDirectory.Path, "saves", loadPath);
+                    }
+
+                    if (!File.Exists(loadPath))
+                        return JsonSerializer.Serialize(new { success = false, error = $"File not found: {loadPath}" });
+
+                    bool result = Tracker.Instance.LoadProgress(loadPath);
+                    return JsonSerializer.Serialize(new { success = result, path = loadPath });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "list_save_files")]
+        [Description("List all save files in the default saves directory")]
+        public static async Task<string> ListSaveFiles()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    string savesDir = Path.Combine(UserDirectory.Path, "saves");
+                    if (!Directory.Exists(savesDir))
+                        return JsonSerializer.Serialize(Array.Empty<object>());
+
+                    var files = Directory.GetFiles(savesDir, "*.json")
+                        .Select(f => new FileInfo(f))
+                        .OrderByDescending(f => f.LastWriteTime)
+                        .Select(f => new
+                        {
+                            name = f.Name,
+                            path = f.FullName,
+                            size = f.Length,
+                            lastModified = f.LastWriteTime.ToString("o")
+                        })
+                        .ToArray();
+
+                    return JsonSerializer.Serialize(files);
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { error = ex.Message });
+                }
+            });
+        }
+    }
+}

--- a/EmoTracker/Extensions/McpServer/Tools/ScreenshotTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/ScreenshotTools.cs
@@ -1,0 +1,111 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using ModelContextProtocol.Server;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer.Tools
+{
+    [McpServerToolType]
+    public class ScreenshotTools
+    {
+        [McpServerTool(Name = "capture_main_window")]
+        [Description("Capture the main tracker window as a base64-encoded PNG screenshot")]
+        public static async Task<string> CaptureMainWindow()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var window = GetMainWindow();
+                    if (window == null)
+                        return JsonSerializer.Serialize(new { error = "Main window not found" });
+
+                    return CaptureWindow(window);
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "capture_broadcast_view")]
+        [Description("Capture the broadcast view window as a base64-encoded PNG screenshot")]
+        public static async Task<string> CaptureBroadcastView()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var lifetime = Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
+                    if (lifetime == null)
+                        return JsonSerializer.Serialize(new { error = "Application lifetime not available" });
+
+                    Window broadcastWindow = null;
+                    foreach (var win in lifetime.Windows)
+                    {
+                        if (win is UI.BroadcastView)
+                        {
+                            broadcastWindow = win;
+                            break;
+                        }
+                    }
+
+                    if (broadcastWindow == null)
+                        return JsonSerializer.Serialize(new { error = "Broadcast view is not open" });
+
+                    return CaptureWindow(broadcastWindow);
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { error = ex.Message });
+                }
+            });
+        }
+
+        private static Window GetMainWindow()
+        {
+            var lifetime = Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
+            return lifetime?.MainWindow;
+        }
+
+        private static string CaptureWindow(Window window)
+        {
+            var pixelSize = new PixelSize(
+                Math.Max(1, (int)window.Bounds.Width),
+                Math.Max(1, (int)window.Bounds.Height));
+
+            var dpi = new Vector(96, 96);
+            if (window.Screens?.Primary != null)
+            {
+                var scaling = window.Screens.Primary.Scaling;
+                dpi = new Vector(96 * scaling, 96 * scaling);
+                pixelSize = new PixelSize(
+                    Math.Max(1, (int)(window.Bounds.Width * scaling)),
+                    Math.Max(1, (int)(window.Bounds.Height * scaling)));
+            }
+
+            var renderTarget = new RenderTargetBitmap(pixelSize, dpi);
+            renderTarget.Render(window);
+
+            using var ms = new MemoryStream();
+            renderTarget.Save(ms);
+            var base64 = Convert.ToBase64String(ms.ToArray());
+
+            return JsonSerializer.Serialize(new
+            {
+                image = base64,
+                width = pixelSize.Width,
+                height = pixelSize.Height,
+                format = "png"
+            });
+        }
+    }
+}

--- a/EmoTracker/Extensions/McpServer/Tools/SettingsTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/SettingsTools.cs
@@ -1,0 +1,152 @@
+using Avalonia.Threading;
+using EmoTracker.Data;
+using ModelContextProtocol.Server;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer.Tools
+{
+    [McpServerToolType]
+    public class SettingsTools
+    {
+        [McpServerTool(Name = "get_settings")]
+        [Description("Get all current application settings")]
+        public static async Task<string> GetSettings()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var s = ApplicationSettings.Instance;
+                return JsonSerializer.Serialize(new
+                {
+                    ignoreAllLogic = s.IgnoreAllLogic,
+                    displayAllLocations = s.DisplayAllLocations,
+                    alwaysAllowClearing = s.AlwaysAllowClearing,
+                    autoUnpinLocationsOnClear = s.AutoUnpinLocationsOnClear,
+                    pinLocationsOnItemCapture = s.PinLocationsOnItemCapture,
+                    fastToolTips = s.FastToolTips,
+                    promptOnRefreshClose = s.PromptOnRefreshClose,
+                    alwaysOnTop = s.AlwaysOnTop,
+                    enableVoiceControl = s.EnableVoiceControl,
+                    enableNoteTaking = s.EnableNoteTaking,
+                    enableDiscordRichPresence = s.EnableDiscordRichPresence,
+                    enableAutoUpdateCheck = s.EnableAutoUpdateCheck,
+                    enableBackgroundNdi = s.EnableBackgroundNdi,
+                    ndiFrameRate = s.NdiFrameRate,
+                    ndiOutputScale = s.NdiOutputScale,
+                    initialWidth = s.InitialWidth,
+                    initialHeight = s.InitialHeight,
+                    lastActivePackage = s.LastActivePackage,
+                    lastActivePackageVariant = s.LastActivePackageVariant,
+                    mapEnabled = Tracker.Instance.MapEnabled,
+                    swapLeftRight = Tracker.Instance.SwapLeftRight
+                });
+            });
+        }
+
+        [McpServerTool(Name = "set_setting")]
+        [Description("Set an application setting by key. Valid keys: ignoreAllLogic, displayAllLocations, alwaysAllowClearing, autoUnpinLocationsOnClear, pinLocationsOnItemCapture, fastToolTips, promptOnRefreshClose, alwaysOnTop, enableVoiceControl, enableNoteTaking, enableDiscordRichPresence, enableAutoUpdateCheck, enableBackgroundNdi, mapEnabled, swapLeftRight")]
+        public static async Task<string> SetSetting(
+            [Description("The setting key")] string key,
+            [Description("The value to set (true/false for booleans)")] string value)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var s = ApplicationSettings.Instance;
+                    bool boolVal;
+
+                    switch (key)
+                    {
+                        case "ignoreAllLogic":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.IgnoreAllLogic = boolVal;
+                            break;
+                        case "displayAllLocations":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.DisplayAllLocations = boolVal;
+                            break;
+                        case "alwaysAllowClearing":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.AlwaysAllowClearing = boolVal;
+                            break;
+                        case "autoUnpinLocationsOnClear":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.AutoUnpinLocationsOnClear = boolVal;
+                            break;
+                        case "pinLocationsOnItemCapture":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.PinLocationsOnItemCapture = boolVal;
+                            break;
+                        case "fastToolTips":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.FastToolTips = boolVal;
+                            break;
+                        case "promptOnRefreshClose":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.PromptOnRefreshClose = boolVal;
+                            break;
+                        case "alwaysOnTop":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.AlwaysOnTop = boolVal;
+                            break;
+                        case "enableVoiceControl":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.EnableVoiceControl = boolVal;
+                            break;
+                        case "enableNoteTaking":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.EnableNoteTaking = boolVal;
+                            break;
+                        case "enableDiscordRichPresence":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.EnableDiscordRichPresence = boolVal;
+                            break;
+                        case "enableAutoUpdateCheck":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.EnableAutoUpdateCheck = boolVal;
+                            break;
+                        case "enableBackgroundNdi":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            s.EnableBackgroundNdi = boolVal;
+                            break;
+                        case "mapEnabled":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            Tracker.Instance.MapEnabled = boolVal;
+                            break;
+                        case "swapLeftRight":
+                            if (!bool.TryParse(value, out boolVal))
+                                return JsonSerializer.Serialize(new { success = false, error = "Expected true/false" });
+                            Tracker.Instance.SwapLeftRight = boolVal;
+                            break;
+                        default:
+                            return JsonSerializer.Serialize(new { success = false, error = $"Unknown setting key: {key}" });
+                    }
+
+                    return JsonSerializer.Serialize(new { success = true, key, value });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+    }
+}

--- a/EmoTracker/Extensions/McpServer/Tools/UiAutomationTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/UiAutomationTools.cs
@@ -1,0 +1,250 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using EmoTracker.Data;
+using ModelContextProtocol.Server;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer.Tools
+{
+    [McpServerToolType]
+    public class UiAutomationTools
+    {
+        [McpServerTool(Name = "click_at")]
+        [Description("Simulate a mouse click at pixel coordinates on the main window. Coordinates are relative to the window client area.")]
+        public static async Task<string> ClickAt(
+            [Description("X coordinate in pixels")] double x,
+            [Description("Y coordinate in pixels")] double y,
+            [Description("Mouse button: 'left', 'right', or 'middle'")] string button = "left")
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var window = GetMainWindow();
+                    if (window == null)
+                        return JsonSerializer.Serialize(new { success = false, error = "Main window not found" });
+
+                    var point = new Point(x, y);
+                    var target = window.InputHitTest(point) as InputElement;
+
+                    if (target == null)
+                        return JsonSerializer.Serialize(new { success = false, error = $"No input element at ({x}, {y})" });
+
+                    var pointerButton = button?.ToLowerInvariant() switch
+                    {
+                        "right" => MouseButton.Right,
+                        "middle" => MouseButton.Middle,
+                        _ => MouseButton.Left
+                    };
+
+                    // Use direct item interaction for tracker items rather than
+                    // synthetic pointer events (which require an IPointer instance)
+                    if (target.DataContext is ITrackableItem trackable)
+                    {
+                        if (pointerButton == MouseButton.Left)
+                            trackable.OnLeftClick();
+                        else if (pointerButton == MouseButton.Right)
+                            trackable.OnRightClick();
+                    }
+                    else
+                    {
+                        // For non-trackable controls, try raising tapped event
+                        var tappedArgs = new Avalonia.Interactivity.RoutedEventArgs(Avalonia.Input.InputElement.TappedEvent);
+                        target.RaiseEvent(tappedArgs);
+                    }
+
+                    return JsonSerializer.Serialize(new
+                    {
+                        success = true,
+                        targetType = target.GetType().Name,
+                        targetName = (target as Control)?.Name
+                    });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "send_key")]
+        [Description("Simulate keyboard input on the main window. Key is an Avalonia Key enum name (e.g. 'F5', 'A', 'Enter'). Modifiers: 'ctrl', 'shift', 'alt', comma-separated.")]
+        public static async Task<string> SendKey(
+            [Description("Key name from Avalonia Key enum (e.g. 'F5', 'A', 'Enter')")] string key,
+            [Description("Comma-separated modifiers: 'ctrl', 'shift', 'alt', 'meta'")] string modifiers = null)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var window = GetMainWindow();
+                    if (window == null)
+                        return JsonSerializer.Serialize(new { success = false, error = "Main window not found" });
+
+                    if (!Enum.TryParse<Key>(key, true, out var parsedKey))
+                        return JsonSerializer.Serialize(new { success = false, error = $"Unknown key: {key}" });
+
+                    var keyMods = KeyModifiers.None;
+                    if (!string.IsNullOrEmpty(modifiers))
+                    {
+                        foreach (var mod in modifiers.Split(',', StringSplitOptions.TrimEntries))
+                        {
+                            switch (mod.ToLowerInvariant())
+                            {
+                                case "ctrl":
+                                case "control":
+                                    keyMods |= KeyModifiers.Control;
+                                    break;
+                                case "shift":
+                                    keyMods |= KeyModifiers.Shift;
+                                    break;
+                                case "alt":
+                                    keyMods |= KeyModifiers.Alt;
+                                    break;
+                                case "meta":
+                                case "win":
+                                    keyMods |= KeyModifiers.Meta;
+                                    break;
+                            }
+                        }
+                    }
+
+                    var downArgs = new KeyEventArgs
+                    {
+                        RoutedEvent = InputElement.KeyDownEvent,
+                        Key = parsedKey,
+                        KeyModifiers = keyMods
+                    };
+                    window.RaiseEvent(downArgs);
+
+                    var upArgs = new KeyEventArgs
+                    {
+                        RoutedEvent = InputElement.KeyUpEvent,
+                        Key = parsedKey,
+                        KeyModifiers = keyMods
+                    };
+                    window.RaiseEvent(upArgs);
+
+                    return JsonSerializer.Serialize(new { success = true, key, modifiers });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "get_window_bounds")]
+        [Description("Get the main window position and size")]
+        public static async Task<string> GetWindowBounds()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var window = GetMainWindow();
+                if (window == null)
+                    return JsonSerializer.Serialize(new { error = "Main window not found" });
+
+                return JsonSerializer.Serialize(new
+                {
+                    x = window.Position.X,
+                    y = window.Position.Y,
+                    width = window.Bounds.Width,
+                    height = window.Bounds.Height,
+                    clientWidth = window.ClientSize.Width,
+                    clientHeight = window.ClientSize.Height
+                });
+            });
+        }
+
+        [McpServerTool(Name = "list_ui_elements")]
+        [Description("List visible interactive UI elements in the main window with their bounds. Use type filter: 'all', 'buttons', 'named'.")]
+        public static async Task<string> ListUiElements(
+            [Description("Filter type: 'all', 'buttons', or 'named' (default)")] string type = "named")
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var window = GetMainWindow();
+                if (window == null)
+                    return JsonSerializer.Serialize(new { error = "Main window not found" });
+
+                var elements = new List<object>();
+                WalkVisualTree(window, window, elements, type ?? "named");
+
+                return JsonSerializer.Serialize(elements);
+            });
+        }
+
+        private static void WalkVisualTree(Visual node, Window root, List<object> elements, string filter)
+        {
+            if (node is Control control && control.IsVisible)
+            {
+                bool include = false;
+
+                switch (filter.ToLowerInvariant())
+                {
+                    case "all":
+                        include = control is InputElement;
+                        break;
+                    case "buttons":
+                        include = control is Avalonia.Controls.Button ||
+                                  control is Avalonia.Controls.Primitives.ToggleButton;
+                        break;
+                    case "named":
+                    default:
+                        include = !string.IsNullOrEmpty(control.Name);
+                        break;
+                }
+
+                if (include)
+                {
+                    try
+                    {
+                        var transform = control.TransformToVisual(root);
+                        if (transform.HasValue)
+                        {
+                            var topLeft = transform.Value.Transform(new Point(0, 0));
+                            var bottomRight = transform.Value.Transform(
+                                new Point(control.Bounds.Width, control.Bounds.Height));
+                            elements.Add(new
+                            {
+                                name = control.Name,
+                                type = control.GetType().Name,
+                                x = topLeft.X,
+                                y = topLeft.Y,
+                                width = bottomRight.X - topLeft.X,
+                                height = bottomRight.Y - topLeft.Y,
+                                isEnabled = control.IsEnabled,
+                                dataContext = control.DataContext?.GetType().Name
+                            });
+                        }
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+
+            if (node is Visual visual)
+            {
+                foreach (var child in visual.GetVisualChildren())
+                {
+                    WalkVisualTree(child, root, elements, filter);
+                }
+            }
+        }
+
+        private static Window GetMainWindow()
+        {
+            var lifetime = Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
+            return lifetime?.MainWindow;
+        }
+    }
+}

--- a/EmoTracker/Extensions/McpServer/Tools/WindowTools.cs
+++ b/EmoTracker/Extensions/McpServer/Tools/WindowTools.cs
@@ -1,0 +1,183 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using ModelContextProtocol.Server;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace EmoTracker.Extensions.McpServer.Tools
+{
+    [McpServerToolType]
+    public class WindowTools
+    {
+        [McpServerTool(Name = "get_layout_scale")]
+        [Description("Get the current main layout zoom level (100-500%)")]
+        public static async Task<string> GetLayoutScale()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                var scale = ApplicationModel.Instance.MainLayoutScale;
+                return JsonSerializer.Serialize(new { scale, scaleFactor = scale / 100.0 });
+            });
+        }
+
+        [McpServerTool(Name = "set_layout_scale")]
+        [Description("Set the main layout zoom level (100-500%)")]
+        public static async Task<string> SetLayoutScale(
+            [Description("Zoom percentage (100-500)")] int scale)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    if (scale < 100 || scale > 500)
+                        return JsonSerializer.Serialize(new { success = false, error = "Scale must be between 100 and 500" });
+
+                    ApplicationModel.Instance.MainLayoutScale = scale;
+                    return JsonSerializer.Serialize(new { success = true, scale, scaleFactor = scale / 100.0 });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "open_broadcast_view")]
+        [Description("Open the broadcast view window")]
+        public static async Task<string> OpenBroadcastView()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    ApplicationModel.Instance.ShowBroadcastViewCommand?.Execute(null);
+                    return JsonSerializer.Serialize(new { success = true });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "close_broadcast_view")]
+        [Description("Close the broadcast view window if it is open")]
+        public static async Task<string> CloseBroadcastView()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var lifetime = Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
+                    if (lifetime == null)
+                        return JsonSerializer.Serialize(new { success = false, error = "Application lifetime not available" });
+
+                    foreach (var win in lifetime.Windows)
+                    {
+                        if (win is UI.BroadcastView bv)
+                        {
+                            bv.Close();
+                            return JsonSerializer.Serialize(new { success = true });
+                        }
+                    }
+
+                    return JsonSerializer.Serialize(new { success = false, error = "Broadcast view is not open" });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "open_developer_console")]
+        [Description("Open the developer console window")]
+        public static async Task<string> OpenDeveloperConsole()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    ApplicationModel.Instance.ShowDeveloperConsoleCommand?.Execute(null);
+                    return JsonSerializer.Serialize(new { success = true });
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+                }
+            });
+        }
+
+        [McpServerTool(Name = "capture_developer_console")]
+        [Description("Capture the developer console window as a base64-encoded PNG screenshot")]
+        public static async Task<string> CaptureDeveloperConsole()
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
+                {
+                    var lifetime = Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
+                    if (lifetime == null)
+                        return JsonSerializer.Serialize(new { error = "Application lifetime not available" });
+
+                    Window consoleWindow = null;
+                    foreach (var win in lifetime.Windows)
+                    {
+                        if (win is UI.DeveloperConsole)
+                        {
+                            consoleWindow = win;
+                            break;
+                        }
+                    }
+
+                    if (consoleWindow == null)
+                        return JsonSerializer.Serialize(new { error = "Developer console is not open" });
+
+                    return CaptureWindow(consoleWindow);
+                }
+                catch (Exception ex)
+                {
+                    return JsonSerializer.Serialize(new { error = ex.Message });
+                }
+            });
+        }
+
+        private static string CaptureWindow(Window window)
+        {
+            var pixelSize = new PixelSize(
+                Math.Max(1, (int)window.Bounds.Width),
+                Math.Max(1, (int)window.Bounds.Height));
+
+            var dpi = new Vector(96, 96);
+            if (window.Screens?.Primary != null)
+            {
+                var scaling = window.Screens.Primary.Scaling;
+                dpi = new Vector(96 * scaling, 96 * scaling);
+                pixelSize = new PixelSize(
+                    Math.Max(1, (int)(window.Bounds.Width * scaling)),
+                    Math.Max(1, (int)(window.Bounds.Height * scaling)));
+            }
+
+            var renderTarget = new RenderTargetBitmap(pixelSize, dpi);
+            renderTarget.Render(window);
+
+            using var ms = new MemoryStream();
+            renderTarget.Save(ms);
+            var base64 = Convert.ToBase64String(ms.ToArray());
+
+            return JsonSerializer.Serialize(new
+            {
+                image = base64,
+                width = pixelSize.Width,
+                height = pixelSize.Height,
+                format = "png"
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an MCP (Model Context Protocol) server extension that runs on `localhost:27125` when the app is launched with `-dev`, enabling external AI tools like Claude Code to programmatically interact with EmoTracker for automated testing
- Provides **48 MCP tools** across 12 categories: pack data, app control, Lua scripting, screenshots, UI automation, settings, locations, save/load, notes, extensions, windows, and packages
- All MCP code (source files, NuGet packages, ASP.NET Core framework reference) is conditionally excluded from Release builds, so GitHub releases ship without any MCP dependencies

## Tool Categories
| Category | Tools |
|----------|-------|
| Pack Data | `get_loaded_pack`, `list_items`, `list_locations`, `get_item_by_name`, `find_item_by_code`, `get_item_details`, `set_item_state`, `batch_toggle_items` |
| App Control | `list_packs`, `load_pack`, `toggle_item`, `right_click_item`, `reset_tracker`, `clear_location`, `shutdown`, `undo` |
| Lua | `get_console_log`, `execute_lua`, `get_lua_global` |
| Screenshots | `capture_main_window`, `capture_broadcast_view` |
| UI Automation | `click_at`, `send_key`, `get_window_bounds`, `list_ui_elements` |
| Settings | `get_settings`, `set_setting` |
| Locations | `get_location`, `pin_location`, `unpin_location`, `list_pinned_locations`, `clear_section`, `unclear_location`, `check_accessibility`, `list_accessible_locations`, `check_code` |
| Save/Load | `save_progress`, `load_progress`, `list_save_files` |
| Notes | `add_note`, `get_notes`, `clear_notes` |
| Extensions | `list_extensions`, `get_autotracker_status` |
| Windows | `get_layout_scale`, `set_layout_scale`, `open_broadcast_view`, `close_broadcast_view`, `open_developer_console`, `capture_developer_console` |
| Packages | `get_pack_files`, `get_pack_file_content`, `reload_pack` |

## Test plan
- [x] Debug build: MCP server starts, all tools respond correctly
- [x] Release build: No MCP server, port 27125 connection refused
- [x] End-to-end test: load pack → track items → clear dungeon → shutdown via MCP
- [ ] Verify CI release workflow still produces clean artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)