### PR TITLE
Add async image pre-caching and batch LuaItem accessibility refresh

### DIFF
--- a/EmoTracker.Data/Media/ImageReference.cs
+++ b/EmoTracker.Data/Media/ImageReference.cs
@@ -1,10 +1,31 @@
 ﻿using EmoTracker.Core;
 using System;
+using System.Collections.Generic;
 
 namespace EmoTracker.Data.Media
 {
     public abstract class ImageReference : ObservableObject
     {
+        static bool sTracking;
+        static List<ImageReference> sTrackedReferences;
+
+        public static List<ImageReference> LastCollectedReferences { get; private set; }
+
+        public static void BeginTrackingCreatedReferences()
+        {
+            sTrackedReferences = new List<ImageReference>();
+            sTracking = true;
+        }
+
+        public static List<ImageReference> EndTrackingCreatedReferences()
+        {
+            sTracking = false;
+            LastCollectedReferences = sTrackedReferences;
+            var result = sTrackedReferences;
+            sTrackedReferences = null;
+            return result;
+        }
+
         public static ImageReference FromPackRelativePath(string path, string filter = null)
         {
             return FromPackRelativePath(Tracker.Instance.ActiveGamePackage, path, filter);
@@ -26,11 +47,16 @@ namespace EmoTracker.Data.Media
                 path = "gamepackage://" + path;
             }
 
-            return new ConcreteImageReference()
+            var result = new ConcreteImageReference()
             {
                 URI = new Uri(path),
                 Filter = filter
             };
+
+            if (sTracking)
+                sTrackedReferences?.Add(result);
+
+            return result;
         }
 
         public static ImageReference FromImageReference(ImageReference existingReference, string filter = null)
@@ -41,11 +67,16 @@ namespace EmoTracker.Data.Media
             if (string.IsNullOrWhiteSpace(filter))
                 return existingReference;
 
-            return new FilterImageReference()
+            var result = new FilterImageReference()
             {
                 Reference = existingReference,
                 Filter = filter
             };
+
+            if (sTracking)
+                sTrackedReferences?.Add(result);
+
+            return result;
         }
 
         public static ImageReference FromExternalURI(Uri uri, string filter = null)
@@ -68,7 +99,12 @@ namespace EmoTracker.Data.Media
             }
 
             if (instance.Layers.Count > 0)
+            {
+                if (sTracking)
+                    sTrackedReferences?.Add(instance);
+
                 return instance;
+            }
 
             return null;
         }

--- a/EmoTracker.Data/Scripting/LuaItem.cs
+++ b/EmoTracker.Data/Scripting/LuaItem.cs
@@ -182,7 +182,17 @@ namespace EmoTracker.Data.Scripting
             try
             {
                 if (OnLeftClickFunc != null)
-                    OnLeftClickFunc.Call(this);
+                {
+                    LocationDatabase.Instance.SuspendRefresh = true;
+                    try
+                    {
+                        OnLeftClickFunc.Call(this);
+                    }
+                    finally
+                    {
+                        LocationDatabase.Instance.SuspendRefresh = false;
+                    }
+                }
             }
             catch (Exception e)
             {
@@ -195,7 +205,17 @@ namespace EmoTracker.Data.Scripting
             try
             {
                 if (OnRightClickFunc != null)
-                OnRightClickFunc.Call(this);
+                {
+                    LocationDatabase.Instance.SuspendRefresh = true;
+                    try
+                    {
+                        OnRightClickFunc.Call(this);
+                    }
+                    finally
+                    {
+                        LocationDatabase.Instance.SuspendRefresh = false;
+                    }
+                }
             }
             catch (Exception e)
             {

--- a/EmoTracker.Data/Tracker.cs
+++ b/EmoTracker.Data/Tracker.cs
@@ -2,6 +2,7 @@
 using EmoTracker.Data.JSON;
 using EmoTracker.Data.Layout;
 using EmoTracker.Data.Locations;
+using EmoTracker.Data.Media;
 using EmoTracker.Data.Packages;
 using EmoTracker.Data.Settings;
 using Newtonsoft.Json;
@@ -482,6 +483,8 @@ An error occurred while saving. This may be due to anti-virus/malware software p
 
                             LoadPackageSettings();
 
+                            ImageReference.BeginTrackingCreatedReferences();
+
                             ScriptManager.Instance.Load(mActiveGamePackage);
 
                             //  Legacy loads - should this be contingent on a flag in the manifest
@@ -494,6 +497,8 @@ An error occurred while saving. This may be due to anti-virus/malware software p
                 }
                 finally
                 {
+                    ImageReference.EndTrackingCreatedReferences();
+
                     AccessibilityRule.ClearCaches();
 
                     mbReloadInProgress = false;

--- a/EmoTracker.UI/Media/ImageReferenceService.cs
+++ b/EmoTracker.UI/Media/ImageReferenceService.cs
@@ -1,7 +1,12 @@
 using EmoTracker.Core;
 using EmoTracker.Data.Media;
 using EmoTracker.UI.Media.Resolvers;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Avalonia.Media;
 
@@ -9,10 +14,14 @@ namespace EmoTracker.UI.Media
 {
     public class ImageReferenceService : ObservableSingleton<ImageReferenceService>
     {
-        Dictionary<ImageReference, IImage> mCache = new Dictionary<ImageReference, IImage>();
+        ConcurrentDictionary<ImageReference, IImage> mCache = new ConcurrentDictionary<ImageReference, IImage>();
+        readonly object mResolutionLock = new object();
+        CancellationTokenSource mPreCacheCts;
 
         public void ClearImageCache()
         {
+            mPreCacheCts?.Cancel();
+            mPreCacheCts = null;
             mCache.Clear();
         }
 
@@ -21,20 +30,80 @@ namespace EmoTracker.UI.Media
             if (imageRef == null)
                 return null;
 
+            // Fast path: lock-free cache read
             if (mCache.TryGetValue(imageRef, out IImage cachedSrc))
                 return cachedSrc;
 
+            // Slow path: acquire lock for resolution
+            lock (mResolutionLock)
+            {
+                // Double-check after acquiring lock (background may have resolved it)
+                if (mCache.TryGetValue(imageRef, out cachedSrc))
+                    return cachedSrc;
+
+                return ResolveAndCache(imageRef);
+            }
+        }
+
+        IImage ResolveAndCache(ImageReference imageRef)
+        {
             foreach (ImageReferenceResolver entry in TypedObjectRegistry<ImageReferenceResolver>.SupportRegistry)
             {
                 if (entry.CanResolveReference(imageRef))
                 {
                     IImage src = entry.ResolveReference(imageRef);
-                    mCache[imageRef] = src;
+                    if (src != null)
+                        mCache[imageRef] = src;
                     return src;
                 }
             }
 
             return null;
+        }
+
+        public Task PreCacheImagesAsync(List<ImageReference> refs)
+        {
+            mPreCacheCts?.Cancel();
+
+            var cts = new CancellationTokenSource();
+            mPreCacheCts = cts;
+            var token = cts.Token;
+
+            // Sort: ConcreteImageReference first (base images), then Filter, then Layered
+            // This avoids redundant recursive resolution during pre-cache
+            var sorted = refs
+                .OrderBy(r => r is ConcreteImageReference ? 0 : r is FilterImageReference ? 1 : 2)
+                .ToList();
+
+            return Task.Run(() =>
+            {
+                foreach (var imageRef in sorted)
+                {
+                    if (token.IsCancellationRequested)
+                        break;
+
+                    // Skip if already cached (lock-free read)
+                    if (mCache.ContainsKey(imageRef))
+                        continue;
+
+                    lock (mResolutionLock)
+                    {
+                        // Double-check after lock
+                        if (mCache.ContainsKey(imageRef))
+                            continue;
+
+                        try
+                        {
+                            ResolveAndCache(imageRef);
+                        }
+                        catch
+                        {
+                            // Swallow individual failures during pre-cache;
+                            // they will surface if the UI requests them later.
+                        }
+                    }
+                }
+            }, token);
         }
     }
 }

--- a/EmoTracker/ApplicationModel.cs
+++ b/EmoTracker/ApplicationModel.cs
@@ -6,6 +6,7 @@ using EmoTracker.Data.Core.Transactions.Processors;
 using EmoTracker.Data.JSON;
 using EmoTracker.Data.Layout;
 using EmoTracker.Data.Locations;
+using EmoTracker.Data.Media;
 using EmoTracker.Data.Packages;
 using EmoTracker.Data.Scripting;
 using EmoTracker.Extensions;
@@ -697,6 +698,11 @@ Failed to save progress to ```{0}```. Make sure you have available disk space an
                 undo.ClearUndoHistory();
 
             OpenPackageDocumentationCommand.RaiseCanExecuteChanged();
+
+            // Kick off background pre-caching of all image references collected during pack load
+            var collectedRefs = ImageReference.LastCollectedReferences;
+            if (collectedRefs != null && collectedRefs.Count > 0)
+                _ = ImageReferenceService.Instance.PreCacheImagesAsync(collectedRefs);
 
             WindowService.Instance.FocusMainWindow();
         }


### PR DESCRIPTION
## Summary

- **Async image pre-caching**: Collects all `ImageReference` objects created during pack load and resolves them on a background thread after load completes. Uses a `ConcurrentDictionary` with a resolution lock for thread-safe access, so the UI either finds images already cached or waits briefly for an in-flight resolution.
- **Batched LuaItem accessibility refresh**: Wraps `LuaItem.OnLeftClick`/`OnRightClick` Lua callbacks in `LocationDatabase.SuspendRefresh`, deferring all accessibility tree walks until the callback finishes. Previously, each icon change inside a Lua callback triggered a full ~120ms tree walk individually — e.g. CodeTracker's "Overworld Tile Swap" set 24 icons, causing 23 redundant refreshes and a ~25s UI freeze. Now batched into a single refresh (~108ms).

## Profiling results (CodeTracker Map Tracker — Overworld Tile Swap toggle)

| Metric | Before | After |
|---|---|---|
| Total freeze | 24,906ms | 10,347ms |
| RefeshAccessibility calls | 23 | 1 |
| Accessibility tree walk time | 2,855ms | 108ms |

Remaining time is image resolution (81 cache misses for newly-created image references during the Lua callback).

## Files changed

- `ImageReference.cs` — Static tracking to collect references during pack load
- `ImageReferenceService.cs` — Thread-safe cache, lock-based resolution, `PreCacheImagesAsync`
- `Tracker.cs` — Wrap pack load with `Begin/EndTrackingCreatedReferences`
- `ApplicationModel.cs` — Trigger `PreCacheImagesAsync` after pack load
- `LuaItem.cs` — `SuspendRefresh` around `OnLeftClick`/`OnRightClick` Lua callbacks

## Test plan

- [ ] Load a pack — all images display correctly on first render
- [ ] Rapid pack switching — no stale images or crashes
- [ ] Toggle CodeTracker's "Overworld Tile Swap" — no multi-second freeze
- [ ] Toggle it back off — still responsive
- [ ] Verify map location accessibility updates correctly after toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)