### PR TITLE
Fix input handling and map popup light-dismiss

### DIFF
--- a/EmoTracker/UI/LocationMapControl.axaml.cs
+++ b/EmoTracker/UI/LocationMapControl.axaml.cs
@@ -34,7 +34,8 @@ namespace EmoTracker.UI
             this.AttachedToVisualTree += LocationMapControl_Loaded;
             this.DetachedFromVisualTree += LocationMapControl_Unloaded;
             this.DoubleTapped += LocationMapControl_DoubleTapped;
-            LocationDetails.Closed += (s, e) => LocationDetails.IsOpen = false;
+            LocationDetails.Opened += LocationDetails_Opened;
+            LocationDetails.Closed += LocationDetails_Closed;
             BadgeDetails.Closed   += (s, e) => BadgeDetails.IsOpen = false;
             BadgeItemsControl.ItemsSource = mBadgeImages;
         }
@@ -63,6 +64,14 @@ namespace EmoTracker.UI
             {
                 w.OnGlobalPreviewKeyDown -= MainWindow_OnGlobalPreviewKeyEvent;
                 w.OnGlobalPreviewKeyUp -= MainWindow_OnGlobalPreviewKeyEvent;
+            }
+
+            // Ensure the global dismiss handler is removed if the popup was still open
+            LocationDetails.IsOpen = false;
+            var topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel != null)
+            {
+                topLevel.RemoveHandler(PointerPressedEvent, TopLevel_PointerPressedTunnel);
             }
         }
 
@@ -138,6 +147,62 @@ namespace EmoTracker.UI
         {
             get => mDetailsLocation;
             set => SetProperty(ref mDetailsLocation, value);
+        }
+
+        /// <summary>
+        /// When the location details popup opens, install a tunneling PointerPressed handler
+        /// on the top-level window so that clicks anywhere outside the popup will close it.
+        /// This replaces IsLightDismissEnabled (which creates an overlay that swallows the
+        /// second click of a double-click sequence).
+        /// </summary>
+        private void LocationDetails_Opened(object? sender, EventArgs e)
+        {
+            var topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel != null)
+            {
+                topLevel.AddHandler(PointerPressedEvent, TopLevel_PointerPressedTunnel, RoutingStrategies.Tunnel);
+            }
+        }
+
+        private void LocationDetails_Closed(object? sender, EventArgs e)
+        {
+            LocationDetails.IsOpen = false;
+            var topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel != null)
+            {
+                topLevel.RemoveHandler(PointerPressedEvent, TopLevel_PointerPressedTunnel);
+            }
+        }
+
+        /// <summary>
+        /// Tunneling handler on the top-level window. Closes the location details popup
+        /// when the pointer press lands outside the popup content. The press still reaches
+        /// the target control (map location, item, etc.) because we don't mark it handled.
+        /// </summary>
+        private void TopLevel_PointerPressedTunnel(object? sender, PointerPressedEventArgs e)
+        {
+            if (!LocationDetails.IsOpen)
+                return;
+
+            // Check whether the press landed inside the popup content.
+            // The popup's child renders on the overlay layer, outside the normal visual tree,
+            // so we walk up from e.Source looking for our LocationDetailsContent control.
+            var source = e.Source as Visual;
+            bool insidePopup = false;
+            while (source != null)
+            {
+                if (source == LocationDetailsContent)
+                {
+                    insidePopup = true;
+                    break;
+                }
+                source = source.GetVisualParent();
+            }
+
+            if (!insidePopup)
+            {
+                LocationDetails.IsOpen = false;
+            }
         }
 
         #endregion
@@ -294,10 +359,10 @@ namespace EmoTracker.UI
 
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
-            // Always close the popup on any press; it will reopen below if a location was clicked.
-            // This avoids using IsLightDismissEnabled (which creates an overlay layer that swallows
-            // the second click of a double-click before OnPointerPressed sees ClickCount=2).
-            LocationDetails.IsOpen = false;
+            // The popup is closed by TopLevel_PointerPressedTunnel (a tunneling handler on the
+            // top-level window) so that clicks on controls outside this map control also dismiss
+            // the popup. The tunnel handler fires before this override, so the popup is already
+            // closed by the time we get here. If a map location was clicked, we reopen it below.
 
             var props = e.GetCurrentPoint(this).Properties;
 

--- a/EmoTracker/UI/TrackableItemControl.axaml
+++ b/EmoTracker/UI/TrackableItemControl.axaml
@@ -8,6 +8,7 @@
     <Grid ToolTip.Tip="{Binding Name}"
           ToolTip.ShowDelay="{Binding FastToolTips, Source={x:Static data:ApplicationSettings.Instance}, Converter={x:Static local:TrackableItemControl.FastToolTipsToDelayConverter}}"
           Opacity="{Binding Converter={x:Static local:TrackableItemControl.NullToZeroOpacityConverter}}"
+          IsHitTestVisible="{Binding IgnoreUserInput, Converter={x:Static converters:BoolInverseConverter.Instance}, FallbackValue=True}"
           PointerReleased="Grid_PointerReleased">
         <Button Command="{Binding OnLeftClickCommand, RelativeSource={RelativeSource AncestorType=local:TrackableItemControl}}"
                 CommandParameter="{Binding}"
@@ -20,9 +21,30 @@
             <Button.Template>
                 <ControlTemplate TargetType="Button">
                     <Grid Background="{x:Null}">
+                        <Image
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Top"
+                            IsVisible="{Binding MaskInput, Converter={x:Static converters:BoolInverseConverter.Instance}, FallbackValue=True}"
+                            Source="{Binding Icon.ResolvedImage, FallbackValue={x:Null}}">
+                            <Image.Width>
+                                <MultiBinding Converter="{x:Static converters:IconDimensionMultiConverter.Instance}" ConverterParameter="Width">
+                                    <Binding Path="IconWidth" RelativeSource="{RelativeSource AncestorType=local:TrackableItemControl}" />
+                                    <Binding Path="IconHeight" RelativeSource="{RelativeSource AncestorType=local:TrackableItemControl}" />
+                                    <Binding Path="Source" RelativeSource="{RelativeSource Self}" />
+                                </MultiBinding>
+                            </Image.Width>
+                            <Image.Height>
+                                <MultiBinding Converter="{x:Static converters:IconDimensionMultiConverter.Instance}" ConverterParameter="Height">
+                                    <Binding Path="IconHeight" RelativeSource="{RelativeSource AncestorType=local:TrackableItemControl}" />
+                                    <Binding Path="IconWidth" RelativeSource="{RelativeSource AncestorType=local:TrackableItemControl}" />
+                                    <Binding Path="Source" RelativeSource="{RelativeSource Self}" />
+                                </MultiBinding>
+                            </Image.Height>
+                        </Image>
                         <controls:InputMaskingImage
                             HorizontalAlignment="Left"
                             VerticalAlignment="Top"
+                            IsVisible="{Binding MaskInput, FallbackValue=False}"
                             Source="{Binding Icon.ResolvedImage, FallbackValue={x:Null}}">
                             <controls:InputMaskingImage.Width>
                                 <MultiBinding Converter="{x:Static converters:IconDimensionMultiConverter.Instance}" ConverterParameter="Width">

--- a/EmoTracker/UI/TrackableItemControl.axaml.cs
+++ b/EmoTracker/UI/TrackableItemControl.axaml.cs
@@ -124,7 +124,12 @@ namespace EmoTracker.UI
                 CanExecuteChanged?.Invoke(this, EventArgs.Empty);
             }
 
-            public bool CanExecute(object? parameter) => true;
+            public bool CanExecute(object? parameter)
+            {
+                if (parameter is ITrackableItem item && item.IgnoreUserInput)
+                    return false;
+                return true;
+            }
 
             public void Execute(object? parameter)
             {
@@ -165,7 +170,12 @@ namespace EmoTracker.UI
                 CanExecuteChanged?.Invoke(this, EventArgs.Empty);
             }
 
-            public bool CanExecute(object? parameter) => true;
+            public bool CanExecute(object? parameter)
+            {
+                if (parameter is ITrackableItem item && item.IgnoreUserInput)
+                    return false;
+                return true;
+            }
 
             public void Execute(object? parameter)
             {
@@ -202,6 +212,12 @@ namespace EmoTracker.UI
         {
             if (e.InitialPressMouseButton == Avalonia.Input.MouseButton.Right)
             {
+                if (DataContext is ITrackableItem item && item.IgnoreUserInput)
+                {
+                    e.Handled = true;
+                    return;
+                }
+
                 mRegressCmd.Execute(DataContext);
                 e.Handled = true;
             }


### PR DESCRIPTION
## Summary
- **MaskInput**: TrackableItemControl now uses standard `Image` (rectangular hit test) by default, only switching to `InputMaskingImage` (per-pixel alpha hit test) when `MaskInput` is true
- **IgnoreUserInput**: Enforced at three levels — `IsHitTestVisible` binding on the outer Grid, `CanExecute` checks on both left/right click commands, and an early guard in `Grid_PointerReleased`
- **Map popup light-dismiss**: Location details popup now closes on clicks anywhere in the window (not just within the map control) using a tunneling `PointerPressed` handler on the top-level window, fixing the issue where clicking items outside the map wouldn't dismiss the popup

## Test plan
- [ ] Load a pack with MaskInput items — verify per-pixel alpha hit testing works only on those items
- [ ] Verify items with `IgnoreUserInput=true` cannot be clicked (left or right)
- [ ] Open a map location popup, then click on a tracker item — popup should close
- [ ] Open a map location popup, click on another map location — popup should switch to new location
- [ ] Double-click a map location — should still pin correctly
- [ ] Rapid pack switching — no crashes or stale handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)