### PR TITLE
Bump assembly versions to 3.0.1.9

### DIFF
--- a/EmoTracker.Core/Properties/AssemblyInfo.cs
+++ b/EmoTracker.Core/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("3.0.1.7")]
-[assembly: AssemblyVersion("3.0.1.7")]
-[assembly: AssemblyFileVersion("3.0.1.7")]
+// [assembly: AssemblyVersion("3.0.1.9")]
+[assembly: AssemblyVersion("3.0.1.9")]
+[assembly: AssemblyFileVersion("3.0.1.9")]

--- a/EmoTracker.Data/Properties/AssemblyInfo.cs
+++ b/EmoTracker.Data/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("3.0.1.7")]
-[assembly: AssemblyVersion("3.0.1.7")]
-[assembly: AssemblyFileVersion("3.0.1.7")]
+// [assembly: AssemblyVersion("3.0.1.9")]
+[assembly: AssemblyVersion("3.0.1.9")]
+[assembly: AssemblyFileVersion("3.0.1.9")]

--- a/EmoTracker.UI/Properties/AssemblyInfo.cs
+++ b/EmoTracker.UI/Properties/AssemblyInfo.cs
@@ -41,6 +41,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("3.0.1.8")]
-[assembly: AssemblyVersion("3.0.1.8")]
-[assembly: AssemblyFileVersion("3.0.1.8")]
+// [assembly: AssemblyVersion("3.0.1.9")]
+[assembly: AssemblyVersion("3.0.1.9")]
+[assembly: AssemblyFileVersion("3.0.1.9")]

--- a/EmoTracker/Properties/AssemblyInfo.cs
+++ b/EmoTracker/Properties/AssemblyInfo.cs
@@ -40,8 +40,8 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("3.0.1.8")]
-[assembly: AssemblyVersion("3.0.1.8")]
-[assembly: AssemblyFileVersion("3.0.1.8")]
+// [assembly: AssemblyVersion("3.0.1.9")]
+[assembly: AssemblyVersion("3.0.1.9")]
+[assembly: AssemblyFileVersion("3.0.1.9")]
 [assembly: NeutralResourcesLanguage("en-US")]
 


### PR DESCRIPTION
## Summary
- Bump AssemblyVersion and AssemblyFileVersion to 3.0.1.9 across all four assemblies (EmoTracker, EmoTracker.UI, EmoTracker.Core, EmoTracker.Data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)