### PR TITLE
Fix doors tracking and improve Lua error reporting

### DIFF
--- a/EmoTracker.Data/ItemDatabase.cs
+++ b/EmoTracker.Data/ItemDatabase.cs
@@ -72,7 +72,7 @@ namespace EmoTracker.Data
                     {
                         foreach (string code in codes)
                         {
-                            string key = code.ToLower();
+                            string key = code;
                             if (!mCodeToProviders.TryGetValue(key, out var list))
                             {
                                 list = new List<ITrackableItem>();
@@ -154,8 +154,6 @@ namespace EmoTracker.Data
 
         internal bool CodeIsProvided(string code)
         {
-            code = code.ToLower();
-
             if (mCodeIndexBuilt)
             {
                 // Check indexed items
@@ -195,8 +193,6 @@ namespace EmoTracker.Data
 
         public uint ProviderCountForCode(string code, out AccessibilityLevel maxAccessibilityLevel)
         {
-            code = code.ToLower();
-
             //  Item codes never constrain accessibility
             maxAccessibilityLevel = AccessibilityLevel.Normal;
 
@@ -231,8 +227,6 @@ namespace EmoTracker.Data
         {
             if (string.IsNullOrWhiteSpace(code))
                 return null;
-
-            code = code.ToLower();
 
             if (mCodeIndexBuilt)
             {
@@ -269,8 +263,6 @@ namespace EmoTracker.Data
 
             if (string.IsNullOrWhiteSpace(code))
                 return found.ToArray();
-
-            code = code.ToLower();
 
             if (mCodeIndexBuilt)
             {

--- a/EmoTracker.Data/ScriptManager.cs
+++ b/EmoTracker.Data/ScriptManager.cs
@@ -4,6 +4,7 @@ using EmoTracker.Data.Media;
 using EmoTracker.Data.Scripting;
 using Newtonsoft.Json;
 using NLua;
+using NLua.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -179,6 +180,15 @@ function print(...)
         _output(printResult)
     end
  end
+
+-- Safe-call wrapper: invokes a function via xpcall so that debug.traceback
+-- captures the Lua call stack at the point of failure.  Returns:
+--   true, result1, result2, ...   on success
+--   false, errorMessageWithTraceback   on failure
+function _safe_call(fn, ...)
+    local args = table.pack(...)
+    return xpcall(function() return fn(table.unpack(args, 1, args.n)) end, debug.traceback)
+end
  ";
 
         IGamePackage mPackage;
@@ -255,7 +265,7 @@ function print(...)
                             byte[] buffer = new byte[s.Length];
                             if (s.Read(buffer, 0, buffer.Length) == buffer.Length)
                             {
-                                result = mLua.DoString(buffer);
+                                result = mLua.DoString(buffer, path);
                             }
                         }
                         else
@@ -410,6 +420,7 @@ function print(...)
         public void OutputException(Exception e)
         {
             JsonReaderException jsonException = e as JsonReaderException;
+            LuaException luaException = e as LuaException;
             if (jsonException != null)
             {
                 ScriptManager.Instance.OutputError("JSON Parse Error");
@@ -419,6 +430,14 @@ function print(...)
 
                     if (!string.IsNullOrWhiteSpace(jsonException.HelpLink))
                         OutputError("  For more information, see: {0}", jsonException.HelpLink);
+                }
+            }
+            else if (luaException != null)
+            {
+                ScriptManager.Instance.OutputError("Lua Execution Error");
+                using (new LoggingBlock())
+                {
+                    ScriptManager.Instance.OutputError(luaException.Message);
                 }
             }
             else
@@ -481,6 +500,49 @@ function print(...)
             }
 
             ClearLogOutput();
+        }
+
+        /// <summary>
+        /// Invokes a LuaFunction via xpcall with debug.traceback as the error handler.
+        /// On success, returns the function's results. On failure, throws a LuaException
+        /// whose message includes the full Lua call stack at the point of failure.
+        /// </summary>
+        [NLua.LuaHide]
+        public object[] SafeCall(LuaFunction func, params object[] args)
+        {
+            if (mLua == null)
+                throw new InvalidOperationException("No Lua environment is loaded");
+
+            using (LuaFunction safeCall = mLua["_safe_call"] as LuaFunction)
+            {
+                if (safeCall == null)
+                    return func.Call(args);  // Fallback if _safe_call not available
+
+                // Build argument array: _safe_call(func, arg1, arg2, ...)
+                object[] callArgs = new object[args.Length + 1];
+                callArgs[0] = func;
+                Array.Copy(args, 0, callArgs, 1, args.Length);
+
+                object[] result = safeCall.Call(callArgs);
+
+                if (result == null || result.Length == 0)
+                    return null;
+
+                bool ok = Convert.ToBoolean(result[0]);
+                if (!ok)
+                {
+                    string errorMsg = result.Length > 1 ? result[1]?.ToString() : "Unknown Lua error";
+                    throw new LuaException(errorMsg);
+                }
+
+                // Strip the leading 'true' status from the results
+                if (result.Length <= 1)
+                    return null;
+
+                object[] actualResults = new object[result.Length - 1];
+                Array.Copy(result, 1, actualResults, 0, actualResults.Length);
+                return actualResults;
+            }
         }
 
         [NLua.LuaHide]
@@ -550,11 +612,11 @@ function print(...)
                         IEnumerable<string> args = tokens.Skip(1);
                         if (args != null && args.Any())
                         {
-                            result = func.Call(args.ToArray<object>());
+                            result = SafeCall(func, args.ToArray<object>());
                         }
                         else
                         {
-                            result = func.Call();
+                            result = SafeCall(func);
                         }
 
                         if (result == null)
@@ -655,7 +717,7 @@ function print(...)
                         using (LuaFunction func = mLua[functionName] as LuaFunction)
                         {
                             if (func != null)
-                                func.Call();
+                                SafeCall(func);
                         }
                     }
                 }
@@ -683,7 +745,7 @@ function print(...)
                         {
                             if (callback != null)
                             {
-                                object[] results = callback.Call(segment);
+                                object[] results = SafeCall(callback, segment);
 
                                 if (results != null && results.Length > 0)
                                     return Convert.ToBoolean(results.First());

--- a/EmoTracker.Data/Scripting/LuaItem.cs
+++ b/EmoTracker.Data/Scripting/LuaItem.cs
@@ -150,7 +150,7 @@ namespace EmoTracker.Data.Scripting
             try
             {
                 if (AdvanceToCodeFunc != null)
-                    AdvanceToCodeFunc.Call(this, code);
+                    ScriptManager.Instance.SafeCall(AdvanceToCodeFunc, this, code);
             }
             catch (Exception e)
             {
@@ -164,7 +164,7 @@ namespace EmoTracker.Data.Scripting
             {
                 if (CanProvideCodeFunc != null)
                 {
-                    object[] result = CanProvideCodeFunc.Call(this, code);
+                    object[] result = ScriptManager.Instance.SafeCall(CanProvideCodeFunc, this, code);
                     if (result != null && result.Length > 0)
                         return Convert.ToBoolean(result.First());
                 }
@@ -185,7 +185,7 @@ namespace EmoTracker.Data.Scripting
                 {
                     using (new LocationDatabase.SuspendRefreshScope())
                     {
-                        OnLeftClickFunc.Call(this);
+                        ScriptManager.Instance.SafeCall(OnLeftClickFunc, this);
                     }
                 }
             }
@@ -203,7 +203,7 @@ namespace EmoTracker.Data.Scripting
                 {
                     using (new LocationDatabase.SuspendRefreshScope())
                     {
-                        OnRightClickFunc.Call(this);
+                        ScriptManager.Instance.SafeCall(OnRightClickFunc, this);
                     }
                 }
             }
@@ -219,7 +219,7 @@ namespace EmoTracker.Data.Scripting
             {
                 if (ProvidesCodeFunc != null)
                 {
-                    object[] result = ProvidesCodeFunc.Call(this, code);
+                    object[] result = ScriptManager.Instance.SafeCall(ProvidesCodeFunc, this, code);
                     if (result != null && result.Length > 0)
                         return Convert.ToUInt32(result.First());
                 }
@@ -242,7 +242,7 @@ namespace EmoTracker.Data.Scripting
             {
                 if (SaveFunc != null)
                 {
-                    object[] results = SaveFunc.Call(this);
+                    object[] results = ScriptManager.Instance.SafeCall(SaveFunc, this);
                     if (results != null && results.Length > 0)
                     {
                         LuaTable saveData = results.First() as LuaTable;
@@ -304,7 +304,7 @@ namespace EmoTracker.Data.Scripting
                         }
                     }
 
-                    object[] results = LoadFunc.Call(this, dataMap);
+                    object[] results = ScriptManager.Instance.SafeCall(LoadFunc, this, dataMap);
                     if (results != null && results.Length > 0)
                         return Convert.ToBoolean(results.First());
 
@@ -326,7 +326,7 @@ namespace EmoTracker.Data.Scripting
                 try
                 {
                     if (PropertyChangedFunc != null)
-                        PropertyChangedFunc.Call(this, key, v);
+                        ScriptManager.Instance.SafeCall(PropertyChangedFunc, this, key, v);
                 }
                 catch (Exception e)
                 {

--- a/EmoTracker/UI/TrackableItemControl.axaml
+++ b/EmoTracker/UI/TrackableItemControl.axaml
@@ -8,7 +8,6 @@
     <Grid ToolTip.Tip="{Binding Name}"
           ToolTip.ShowDelay="{Binding FastToolTips, Source={x:Static data:ApplicationSettings.Instance}, Converter={x:Static local:TrackableItemControl.FastToolTipsToDelayConverter}}"
           Opacity="{Binding Converter={x:Static local:TrackableItemControl.NullToZeroOpacityConverter}}"
-          IsHitTestVisible="{Binding IgnoreUserInput, Converter={x:Static converters:BoolInverseConverter.Instance}, FallbackValue=True}"
           PointerReleased="Grid_PointerReleased">
         <Button Command="{Binding OnLeftClickCommand, RelativeSource={RelativeSource AncestorType=local:TrackableItemControl}}"
                 CommandParameter="{Binding}"

--- a/EmoTracker/UI/TrackableItemControl.axaml.cs
+++ b/EmoTracker/UI/TrackableItemControl.axaml.cs
@@ -124,12 +124,10 @@ namespace EmoTracker.UI
                 CanExecuteChanged?.Invoke(this, EventArgs.Empty);
             }
 
-            public bool CanExecute(object? parameter)
-            {
-                if (parameter is ITrackableItem item && item.IgnoreUserInput)
-                    return false;
-                return true;
-            }
+            // CanExecute always returns true so that IClickHandler (e.g. capture grid)
+            // can intercept clicks even on items with IgnoreUserInput=true.
+            // The IgnoreUserInput guard is in Execute, after the IClickHandler check.
+            public bool CanExecute(object? parameter) => true;
 
             public void Execute(object? parameter)
             {
@@ -170,12 +168,10 @@ namespace EmoTracker.UI
                 CanExecuteChanged?.Invoke(this, EventArgs.Empty);
             }
 
-            public bool CanExecute(object? parameter)
-            {
-                if (parameter is ITrackableItem item && item.IgnoreUserInput)
-                    return false;
-                return true;
-            }
+            // CanExecute always returns true so that IClickHandler (e.g. capture grid)
+            // can intercept clicks even on items with IgnoreUserInput=true.
+            // The IgnoreUserInput guard is in Execute, after the IClickHandler check.
+            public bool CanExecute(object? parameter) => true;
 
             public void Execute(object? parameter)
             {
@@ -212,12 +208,6 @@ namespace EmoTracker.UI
         {
             if (e.InitialPressMouseButton == Avalonia.Input.MouseButton.Right)
             {
-                if (DataContext is ITrackableItem item && item.IgnoreUserInput)
-                {
-                    e.Handled = true;
-                    return;
-                }
-
                 mRegressCmd.Execute(DataContext);
                 e.Handled = true;
             }


### PR DESCRIPTION
## Summary
- **Fix case-sensitive code lookups**: Remove `ToLower()` calls in `ItemDatabase` code provider indexing that broke Lua packs using case-sensitive item codes (e.g. door slots in CodeTracker)
- **Fix IgnoreUserInput blocking IClickHandler**: `CanExecute` now always returns `true` so capture grids can intercept clicks on `IgnoreUserInput` items; the guard runs in `Execute` after the `IClickHandler` check. Removed `IsHitTestVisible` binding that blocked all interaction.
- **Add Lua call stack tracing**: All Lua call sites now use `xpcall` + `debug.traceback` via `SafeCall()`, providing full Lua call stacks in developer console error output
- **Improved error formatting**: Dedicated `LuaException` handling in `OutputException` for cleaner developer console output; script paths passed to `DoString` for better error source identification

Closes #41

## Test plan
- [ ] Load CodeTracker pack with Door Shuffle variant
- [ ] Verify door slot items are clickable and capture grid appears
- [ ] Verify regular items with IgnoreUserInput=true still block default click behavior
- [ ] Trigger a Lua error and verify the developer console shows a full Lua call stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)