### PR TITLE
Add ClipToBounds to GroupBox layout element

### DIFF
--- a/EmoTracker/UI/LayoutControl.axaml
+++ b/EmoTracker/UI/LayoutControl.axaml
@@ -360,6 +360,7 @@
                 <Grid Width="{Binding Width, Converter={x:Static converters:NegativeToNaNDoubleConverter.Instance}}"
                       Height="{Binding Height, Converter={x:Static converters:NegativeToNaNDoubleConverter.Instance}}"
                       IsHitTestVisible="{Binding HitTestVisible}"
+                      ClipToBounds="True"
                       MinWidth="{Binding MinWidth, Converter={x:Static converters:NegativeToZeroDoubleConverter.Instance}}"
                       MinHeight="{Binding MinHeight, Converter={x:Static converters:NegativeToZeroDoubleConverter.Instance}}"
                       MaxWidth="{Binding MaxWidth, Converter={x:Static converters:NegativeToInfinityDoubleConverter.Instance}}"


### PR DESCRIPTION
## Summary
- Add `ClipToBounds="True"` to the GroupBox DataTemplate's outer Grid so child content is clipped to the GroupBox's bounds instead of overflowing visually

## Test plan
- [ ] Load a pack with GroupBox layout elements containing content that exceeds the box size
- [ ] Verify content is clipped at the GroupBox boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)