### PR TITLE
Fix collection modified during enumeration in package update checks

### DIFF
--- a/EmoTracker.Data/Packages/PackageManager.cs
+++ b/EmoTracker.Data/Packages/PackageManager.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Net;
 
 namespace EmoTracker.Data.Packages
@@ -269,11 +270,11 @@ namespace EmoTracker.Data.Packages
         {
             get
             {
-                foreach (PackageRepository repository in Repositories)
+                foreach (PackageRepository repository in Repositories.ToList())
                 {
-                    foreach (PackageRepositoryEntry entry in repository.Packages)
+                    foreach (PackageRepositoryEntry entry in repository.Packages.ToList())
                     {
-                        if (entry.Status == PackageRepositoryEntry.PackageStatus.UpdateAvailable)
+                        if (entry != null && entry.Status == PackageRepositoryEntry.PackageStatus.UpdateAvailable)
                             return true;
                     }
                 }
@@ -286,11 +287,11 @@ namespace EmoTracker.Data.Packages
         {
             get
             {
-                foreach (PackageRepository repository in Repositories)
+                foreach (PackageRepository repository in Repositories.ToList())
                 {
-                    foreach (PackageRepositoryEntry entry in repository.Packages)
+                    foreach (PackageRepositoryEntry entry in repository.Packages.ToList())
                     {
-                        if (entry.Status == PackageRepositoryEntry.PackageStatus.UpdateAvailable)
+                        if (entry != null && entry.Status == PackageRepositoryEntry.PackageStatus.UpdateAvailable)
                         {
                             if (entry.ExistingPackage == Tracker.Instance.ActiveGamePackage)
                                 return true;


### PR DESCRIPTION
## Summary
- Iterate `.ToList()` snapshots of `Repositories` and `Packages` collections in `UpdatesAvailable` and `CurrentPackageHasUpdateAvailable` to avoid `InvalidOperationException` when collections are modified concurrently
- Add null checks on entries for safety

Based on codemann8's fix (codemann8/EmoTracker@617da7a).

Fixes #14

## Test plan
- [ ] Let EmoTracker run for 30+ minutes with package repositories configured
- [ ] Verify no crash from "Collection was modified; enumeration operation may not execute"

🤖 Generated with [Claude Code](https://claude.com/claude-code)