### PR TITLE
Fix tabbed layout tab ordering

### DIFF
--- a/EmoTracker/UI/LayoutControl.axaml
+++ b/EmoTracker/UI/LayoutControl.axaml
@@ -256,30 +256,31 @@
                                 Background="Transparent"
                                 SelectedItem="{Binding CurrentTab, Mode=TwoWay}"
                                 Padding="0">
+                        <!-- Set Template directly (local value, highest priority) so the tab-header
+                             strip always renders items in their source/definition order.  Using a
+                             Style Selector="TabControl" override inside TabControl.Styles instead
+                             can lose ordering because style setters are evaluated after the Fluent
+                             theme template has already been applied. -->
+                        <TabControl.Template>
+                            <ControlTemplate>
+                                <Grid RowDefinitions="Auto,*">
+                                    <ItemsPresenter Name="PART_ItemsPresenter"
+                                                    Grid.Row="0"
+                                                    HorizontalAlignment="Center"
+                                                    Margin="0,3">
+                                        <ItemsPresenter.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <WrapPanel Orientation="Horizontal" />
+                                            </ItemsPanelTemplate>
+                                        </ItemsPresenter.ItemsPanel>
+                                    </ItemsPresenter>
+                                    <ContentPresenter Name="PART_SelectedContentHost" Grid.Row="1"
+                                                      Content="{TemplateBinding SelectedContent}"
+                                                      ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
+                                </Grid>
+                            </ControlTemplate>
+                        </TabControl.Template>
                         <TabControl.Styles>
-                            <!-- Style the tab strip area -->
-                            <Style Selector="TabControl">
-                                <Setter Property="Template">
-                                    <ControlTemplate>
-                                        <Grid RowDefinitions="Auto,*">
-                                            <WrapPanel Grid.Row="0" HorizontalAlignment="Center" Margin="0,3">
-                                                <ItemsPresenter Name="PART_ItemsPresenter" />
-                                            </WrapPanel>
-                                            <ContentPresenter Name="PART_SelectedContentHost" Grid.Row="1"
-                                                              Content="{TemplateBinding SelectedContent}"
-                                                              ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
-                                        </Grid>
-                                    </ControlTemplate>
-                                </Setter>
-                            </Style>
-                            <!-- Force the items panel to use horizontal layout -->
-                            <Style Selector="TabControl ItemsPresenter">
-                                <Setter Property="ItemsPanel">
-                                    <ItemsPanelTemplate>
-                                        <WrapPanel Orientation="Horizontal" />
-                                    </ItemsPanelTemplate>
-                                </Setter>
-                            </Style>
                             <!-- Custom TabItem template to fully control all visual states -->
                             <Style Selector="TabItem">
                                 <Setter Property="FontSize" Value="12" />


### PR DESCRIPTION
## Summary

- Tabs in `tabbed` layout elements were displaying in an order other than their JSON definition order
- The root cause: `TabControl.Template` was set via a `Style Selector="TabControl"` inside `TabControl.Styles` — a style setter, which has lower property-value priority than a local value and is evaluated after the Fluent theme's `ControlTheme` has already been applied
- This created a window where the Fluent theme template could render tabs in its own order before the style-setter override took effect
- Same issue applied to `ItemsPanel` being set via a separate `Style Selector="TabControl ItemsPresenter"` setter

## Changes

- Set `TabControl.Template` as a direct property (local value, highest priority, applied before visual tree attachment) instead of via a style override
- Inlined `ItemsPresenter.ItemsPanel` directly in the template, removing the second style-timing dependency
- `TabItem` visual styles remain in `TabControl.Styles` (no ordering implications)

## Test plan

- [ ] Load a pack with a `tabbed` layout element containing 3+ tabs
- [ ] Verify tabs appear in the same left-to-right order as defined in the pack's JSON layout file

🤖 Generated with [Claude Code](https://claude.com/claude-code)