### PR TITLE
Bundle libvosk native library in CI builds

### DIFF
--- a/.github/workflows/build-avalonia.yml
+++ b/.github/workflows/build-avalonia.yml
@@ -66,6 +66,32 @@ jobs:
           curl -fsSL "https://github.com/spatialaudio/portaudio-binaries/raw/master/libportaudio64bit.dll" \
             -o "publish/raw/portaudio.dll"
 
+      - name: Bundle libvosk (Windows only)
+        if: startsWith(matrix.rid, 'win')
+        shell: bash
+        run: |
+          VOSK_NATIVE=$(find ~/.nuget/packages -path "*/vosk/*/runtimes/win-x64/native/libvosk.dll" -print -quit 2>/dev/null)
+          if [ -n "$VOSK_NATIVE" ]; then
+            cp "$VOSK_NATIVE" publish/raw/libvosk.dll
+            echo "Bundled libvosk.dll from: $VOSK_NATIVE"
+          else
+            echo "::error::libvosk.dll not found in NuGet cache — voice recognition will not work"
+            exit 1
+          fi
+
+      - name: Bundle libvosk (Linux only)
+        if: startsWith(matrix.rid, 'linux')
+        shell: bash
+        run: |
+          VOSK_NATIVE=$(find ~/.nuget/packages -path "*/vosk/*/runtimes/linux-x64/native/libvosk.so" -print -quit 2>/dev/null)
+          if [ -n "$VOSK_NATIVE" ]; then
+            cp "$VOSK_NATIVE" publish/raw/libvosk.so
+            echo "Bundled libvosk.so from: $VOSK_NATIVE"
+          else
+            echo "::error::libvosk.so not found in NuGet cache — voice recognition will not work"
+            exit 1
+          fi
+
       - name: Stage Windows output
         if: startsWith(matrix.rid, 'win')
         run: |
@@ -106,6 +132,22 @@ jobs:
           VER=$(sed -n 's/.*AssemblyFileVersion("\([^"]*\)").*/\1/p' EmoTracker/Properties/AssemblyInfo.cs)
           echo "app_version=$VER" >> "$GITHUB_OUTPUT"
           echo "Detected version: $VER"
+
+      - name: Bundle libvosk (macOS)
+        run: |
+          for arch in x64 arm64; do
+            VOSK_NATIVE=$(find ~/.nuget/packages -path "*/vosk/*/runtimes/osx-${arch}/native/libvosk.dylib" -print -quit 2>/dev/null)
+            if [ -z "$VOSK_NATIVE" ]; then
+              VOSK_NATIVE=$(find ~/.nuget/packages -path "*/vosk/*/runtimes/osx/native/libvosk.dylib" -print -quit 2>/dev/null)
+            fi
+            if [ -n "$VOSK_NATIVE" ]; then
+              cp "$VOSK_NATIVE" "publish/${arch}/libvosk.dylib"
+              echo "Bundled libvosk.dylib (${arch}) from: $VOSK_NATIVE"
+            else
+              echo "::error::libvosk.dylib not found in NuGet cache for ${arch} — voice recognition will not work"
+              exit 1
+            fi
+          done
 
       - name: Create universal binary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,18 @@ jobs:
           curl -fsSL "https://github.com/spatialaudio/portaudio-binaries/raw/master/libportaudio64bit.dll" \
             -o "publish/win-x64/portaudio.dll"
 
+      - name: Bundle libvosk for Windows
+        shell: bash
+        run: |
+          VOSK_NATIVE=$(find ~/.nuget/packages -path "*/vosk/*/runtimes/win-x64/native/libvosk.dll" -print -quit 2>/dev/null)
+          if [ -n "$VOSK_NATIVE" ]; then
+            cp "$VOSK_NATIVE" publish/win-x64/libvosk.dll
+            echo "Bundled libvosk.dll from: $VOSK_NATIVE"
+          else
+            echo "::error::libvosk.dll not found in NuGet cache — voice recognition will not work"
+            exit 1
+          fi
+
       - name: Publish osx-x64
         run: dotnet publish EmoTracker/EmoTracker.csproj --framework net8.0 --configuration Release --runtime osx-x64 --self-contained --output publish/osx-x64
 
@@ -48,6 +60,32 @@ jobs:
 
       - name: Publish linux-x64
         run: dotnet publish EmoTracker/EmoTracker.csproj --framework net8.0 --configuration Release --runtime linux-x64 --self-contained --output publish/linux-x64
+
+      - name: Bundle libvosk for macOS and Linux
+        shell: bash
+        run: |
+          for arch in x64 arm64; do
+            VOSK_NATIVE=$(find ~/.nuget/packages -path "*/vosk/*/runtimes/osx-${arch}/native/libvosk.dylib" -print -quit 2>/dev/null)
+            if [ -z "$VOSK_NATIVE" ]; then
+              VOSK_NATIVE=$(find ~/.nuget/packages -path "*/vosk/*/runtimes/osx/native/libvosk.dylib" -print -quit 2>/dev/null)
+            fi
+            if [ -n "$VOSK_NATIVE" ]; then
+              cp "$VOSK_NATIVE" "publish/osx-${arch}/libvosk.dylib"
+              echo "Bundled libvosk.dylib (${arch}) from: $VOSK_NATIVE"
+            else
+              echo "::error::libvosk.dylib not found in NuGet cache for ${arch} — voice recognition will not work"
+              exit 1
+            fi
+          done
+
+          VOSK_NATIVE=$(find ~/.nuget/packages -path "*/vosk/*/runtimes/linux-x64/native/libvosk.so" -print -quit 2>/dev/null)
+          if [ -n "$VOSK_NATIVE" ]; then
+            cp "$VOSK_NATIVE" publish/linux-x64/libvosk.so
+            echo "Bundled libvosk.so from: $VOSK_NATIVE"
+          else
+            echo "::error::libvosk.so not found in NuGet cache — voice recognition will not work"
+            exit 1
+          fi
 
       - name: Create universal macOS binary
         run: |


### PR DESCRIPTION
## Summary

- Voice recognition was silently broken in published releases because `libvosk` (the native Vosk library) was never included in CI build output
- `Vosk.dll` (the managed wrapper) was present, but the P/Invoke call to `libvosk` failed at runtime with `DllNotFoundException`
- This mirrors the existing pattern for PortAudio, which is already explicitly bundled — `libvosk` just wasn't handled the same way

## Changes

Adds "Bundle libvosk" steps to both workflow files that copy the native library from the NuGet package cache (populated during `dotnet publish`) to the publish output directory:

- **Windows** (`build-avalonia.yml`, `release.yml`): copies `libvosk.dll`
- **Linux** (`build-avalonia.yml`, `release.yml`): copies `libvosk.so`
- **macOS** (`build-avalonia.yml`, `release.yml`): copies `libvosk.dylib` to both `osx-x64` and `osx-arm64` outputs; the existing `lipo` loop automatically merges them into a universal binary

Steps fail loudly with `::error::` if the library isn't found in the NuGet cache, rather than producing a broken build silently.

## Test plan

- [ ] Trigger a CI build and confirm the "Bundle libvosk" steps succeed and print the source path
- [ ] Download a build artifact and verify `libvosk.dll` / `libvosk.so` / `libvosk.dylib` is present alongside the executable
- [ ] Confirm voice recognition initializes without the `[Voice] Vosk native library not available` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)