### PR TITLE
Fix groupboxes and package manager not clipping content properly

### DIFF
--- a/EmoTracker/UI/LayoutControl.axaml
+++ b/EmoTracker/UI/LayoutControl.axaml
@@ -399,7 +399,7 @@
                     </Grid>
                     <!-- Content area -->
                     <Grid Grid.Row="1"
-                          Background="{Binding Background, Converter={x:Static converters:StringToBrushConverter.Instance}, TargetNullValue=#66212121, FallbackValue=#66212121}">
+                          Background="{Binding Background, Converter={x:Static converters:StringToBrushConverter.Instance}, TargetNullValue=#66212121, FallbackValue=#66212121}" ClipToBounds="True">
                         <!-- Use a single-cell Grid panel (not StackPanel) so children
                              receive the GroupBox content area's finite height constraint.
                              StackPanel measures children at infinite height in the stacking

--- a/EmoTracker/UI/PackageManagerWindow.axaml
+++ b/EmoTracker/UI/PackageManagerWindow.axaml
@@ -132,7 +132,7 @@
         <!-- Package list -->
         <ScrollViewer Grid.Row="1" Grid.Column="1"
                       VerticalScrollBarVisibility="Auto"
-                      HorizontalScrollBarVisibility="Disabled">
+                      HorizontalScrollBarVisibility="Disabled" ClipToBounds="True">
             <Grid TextElement.Foreground="WhiteSmoke" Grid.IsSharedSizeScope="True" MinHeight="50">
 
                 <!-- Empty state message -->


### PR DESCRIPTION
## Summary
- Fix `ClipToBounds` on groupboxes in `LayoutControl.axaml` so content doesn't overflow
- Fix `ClipToBounds` on the Package Manager window so content is properly clipped

## Test plan
- [ ] Open a layout with groupboxes and verify content stays clipped within bounds
- [ ] Open the Package Manager and verify content does not overflow its container

🤖 Generated with [Claude Code](https://claude.com/claude-code)