### PR TITLE
Add CurrentPlatform, UserDirectory, and ConcatenatePaths to TrackerScriptInterface

### DIFF
--- a/EmoTracker.Data/ScriptManager.cs
+++ b/EmoTracker.Data/ScriptManager.cs
@@ -156,6 +156,26 @@ namespace EmoTracker.Data
             set { mState.Settings.AutoUnpinLocationsOnClear = value; }
         }
 
+        public string CurrentPlatform
+        {
+            get
+            {
+                if (OperatingSystem.IsWindows()) return "windows";
+                if (OperatingSystem.IsMacOS()) return "macos";
+                return "linux";
+            }
+        }
+
+        public string UserDirectory
+        {
+            get { return EmoTracker.Core.UserDirectory.Path; }
+        }
+
+        public string ConcatenatePaths(params string[] paths)
+        {
+            return System.IO.Path.Combine(paths);
+        }
+
     }
 
     class LayoutScriptInterface

--- a/EmoTracker.Data/ScriptManager.cs
+++ b/EmoTracker.Data/ScriptManager.cs
@@ -162,7 +162,8 @@ namespace EmoTracker.Data
             {
                 if (OperatingSystem.IsWindows()) return "windows";
                 if (OperatingSystem.IsMacOS()) return "macos";
-                return "linux";
+                if (OperatingSystem.IsLinux()) return "linux";
+                return "unknown";
             }
         }
 


### PR DESCRIPTION
## Summary

- `Tracker.CurrentPlatform` — string property returning `"windows"`, `"macos"`, or `"linux"`
- `Tracker.UserDirectory` — string property returning the EmoTracker user directory path
- `Tracker.ConcatenatePaths(...)` — variadic function wrapping `System.IO.Path.Combine` for use in Lua scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)