### PR TITLE
Fix variant-switch image caching (issue #79)

### DIFF
--- a/EmoTracker.Data/Items/CompositeToggleItem.cs
+++ b/EmoTracker.Data/Items/CompositeToggleItem.cs
@@ -115,7 +115,7 @@ namespace EmoTracker.Data.Items
             foreach (JObject imageData in imageMap)
             {
                 string imgName = imageData.GetValue<string>("img");
-                var img = ImageReference.FromPackRelativePath(package, imgName, imageData.GetValue<string>("img_mods"));
+                var img = ImageReference.FromPackRelativePath((this.OwnerState as Sessions.TrackerState)?.PackageInstance, imgName, imageData.GetValue<string>("img_mods"));
 
                 if (img != null)
                 {

--- a/EmoTracker.Data/Items/ConsumableItem.cs
+++ b/EmoTracker.Data/Items/ConsumableItem.cs
@@ -236,10 +236,11 @@ namespace EmoTracker.Data.Items
             mCodeProvider.Clear();
             mCodeProvider.AddCodes(data.GetValue<string>("codes"));
 
-            mFullIcon = ImageReference.FromPackRelativePath(package, data.GetValue<string>("img"), data.GetValue<string>("img_mods"));
+            var pi = (this.OwnerState as Sessions.TrackerState)?.PackageInstance;
+            mFullIcon = ImageReference.FromPackRelativePath(pi, data.GetValue<string>("img"), data.GetValue<string>("img_mods"));
 
             //  Allow loading a custom disabled image, and then apply filters
-            mEmptyIcon = ImageReference.FromPackRelativePath(package, data.GetValue<string>("disabled_img"), data.GetValue<string>("disabled_img_mods") ?? DisabledImageFilterSpec);
+            mEmptyIcon = ImageReference.FromPackRelativePath(pi, data.GetValue<string>("disabled_img"), data.GetValue<string>("disabled_img_mods") ?? DisabledImageFilterSpec);
             if (mEmptyIcon == null)
                 mEmptyIcon = ImageReference.FromImageReference(mFullIcon, data.GetValue<string>("disabled_img_mods") ?? DisabledImageFilterSpec);
 

--- a/EmoTracker.Data/Items/ProgressiveItem.cs
+++ b/EmoTracker.Data/Items/ProgressiveItem.cs
@@ -215,10 +215,11 @@ namespace EmoTracker.Data.Items
 
             string codes = "";
 
+            var pi = (this.OwnerState as Sessions.TrackerState)?.PackageInstance;
             JArray stages = (JArray)data.GetValue("stages");
             foreach (JObject stageData in stages)
             {
-                var img = ImageReference.FromPackRelativePath(package, stageData.GetValue<string>("img"), stageData.GetValue<string>("img_mods"));
+                var img = ImageReference.FromPackRelativePath(pi, stageData.GetValue<string>("img"), stageData.GetValue<string>("img_mods"));
 
                 //  Reset the code inheritance chain if requested
                 bool bInheritCodes = stageData.GetValue<bool>("inherit_codes", true);

--- a/EmoTracker.Data/Items/ProgressiveToggleItem.cs
+++ b/EmoTracker.Data/Items/ProgressiveToggleItem.cs
@@ -178,11 +178,12 @@ namespace EmoTracker.Data.Items
 
             uint stageIdx = 0;
 
+            var pi = (this.OwnerState as Sessions.TrackerState)?.PackageInstance;
             JArray stages = (JArray)data.GetValue("stages");
             foreach (JObject stageData in stages)
             {
-                var img = ImageReference.FromPackRelativePath(package, stageData.GetValue<string>("img"), stageData.GetValue<string>("img_mods"));
-                var disabledImg = ImageReference.FromPackRelativePath(package, stageData.GetValue<string>("disabled_img"), stageData.GetValue<string>("disabled_img_mods") ?? DisabledImageFilterSpec);
+                var img = ImageReference.FromPackRelativePath(pi, stageData.GetValue<string>("img"), stageData.GetValue<string>("img_mods"));
+                var disabledImg = ImageReference.FromPackRelativePath(pi, stageData.GetValue<string>("disabled_img"), stageData.GetValue<string>("disabled_img_mods") ?? DisabledImageFilterSpec);
 
                 if (img != null)
                 {

--- a/EmoTracker.Data/Items/StaticItem.cs
+++ b/EmoTracker.Data/Items/StaticItem.cs
@@ -53,7 +53,7 @@ namespace EmoTracker.Data.Items
 
         protected override void ParseDataInternal(JObject data, IGamePackage package)
         {
-            Icon = ImageReference.FromPackRelativePath(package, data.GetValue<string>("img"), data.GetValue<string>("img_mods"));
+            Icon = ImageReference.FromPackRelativePath((this.OwnerState as Sessions.TrackerState)?.PackageInstance, data.GetValue<string>("img"), data.GetValue<string>("img_mods"));
             mCodeProvider.AddCodes(data.GetValue<string>("codes"));
             Capturable = data.GetValue<bool>("capturable", false);
         }

--- a/EmoTracker.Data/Items/ToggleBadgedItem.cs
+++ b/EmoTracker.Data/Items/ToggleBadgedItem.cs
@@ -140,8 +140,9 @@ namespace EmoTracker.Data.Items
             string disabledImgMods = data.GetValue<string>("disabled_img_spec");
             disabledImgMods = data.GetValue<string>("disabled_img_mods", disabledImgMods);
 
-            mInactiveIcon = ImageReference.FromPackRelativePath(package, data.GetValue<string>("disabled_img"), disabledImgMods ?? DisabledImageFilterSpec);
-            ActiveIcon = ImageReference.FromPackRelativePath(package, data.GetValue<string>("img"), data.GetValue<string>("img_mods"));
+            var pi = (this.OwnerState as Sessions.TrackerState)?.PackageInstance;
+            mInactiveIcon = ImageReference.FromPackRelativePath(pi, data.GetValue<string>("disabled_img"), disabledImgMods ?? DisabledImageFilterSpec);
+            ActiveIcon = ImageReference.FromPackRelativePath(pi, data.GetValue<string>("img"), data.GetValue<string>("img_mods"));
 
             Active = data.GetValue<bool>("initial_active_state", Active);
             AddProvidedCodes(data.GetValue<string>("codes"));

--- a/EmoTracker.Data/Items/ToggleItem.cs
+++ b/EmoTracker.Data/Items/ToggleItem.cs
@@ -133,12 +133,13 @@ namespace EmoTracker.Data.Items
         protected override void ParseDataInternal(JObject data, IGamePackage package)
         {
             string imgName = data.GetValue<string>("img");
-            ActiveIcon = ImageReference.FromPackRelativePath(package, imgName, data.GetValue<string>("img_mods"));
+            var pi = (this.OwnerState as Sessions.TrackerState)?.PackageInstance;
+            ActiveIcon = ImageReference.FromPackRelativePath(pi, imgName, data.GetValue<string>("img_mods"));
 
             string disabledImgMods = data.GetValue<string>("disabled_img_spec", DisabledImageFilterSpec);
             disabledImgMods = data.GetValue<string>("disabled_img_mods", disabledImgMods);
 
-            mInactiveIcon = ImageReference.FromPackRelativePath(package, data.GetValue<string>("disabled_img"), disabledImgMods);
+            mInactiveIcon = ImageReference.FromPackRelativePath(pi, data.GetValue<string>("disabled_img"), disabledImgMods);
 
             if (mActiveIcon != null && mInactiveIcon == null)
                 mInactiveIcon = ImageReference.FromImageReference(mActiveIcon, disabledImgMods);

--- a/EmoTracker.Data/Layout/ButtonPopup.cs
+++ b/EmoTracker.Data/Layout/ButtonPopup.cs
@@ -66,7 +66,7 @@ namespace EmoTracker.Data.Layout
         {
             definition[nameof(Style) + "__def"] = data.GetEnumValue<ButtonStyle>("style", ButtonStyle.Settings);
             definition[nameof(Image) + "__def"] = ImageReference.FromPackRelativePath(
-                package, data.GetValue<string>("image"), data.GetValue<string>("image_filter"));
+                (this.OwnerState as Sessions.TrackerState)?.PackageInstance, data.GetValue<string>("image"), data.GetValue<string>("image_filter"));
             definition[nameof(PopupBackground) + "__def"] = data.GetValue<string>("popup_background", "#ff212121");
             definition[nameof(MaskInput) + "__def"] = data.GetValue<bool>("mask_input", false);
             definition[nameof(LayoutKey)] = data.GetValue<string>("layout");

--- a/EmoTracker.Data/Layout/Image.cs
+++ b/EmoTracker.Data/Layout/Image.cs
@@ -20,7 +20,7 @@ namespace EmoTracker.Data.Layout
         protected override void PopulateDefinitionData(JObject data, IGamePackage package, Dictionary<string, object> definition)
         {
             definition[nameof(Content) + "__def"] = ImageReference.FromPackRelativePath(
-                package, data.GetValue<string>("image"), data.GetValue<string>("image_filter"));
+                (this.OwnerState as Sessions.TrackerState)?.PackageInstance, data.GetValue<string>("image"), data.GetValue<string>("image_filter"));
         }
 
         protected override bool TryParseInternal(JObject data, IGamePackage package)

--- a/EmoTracker.Data/Layout/TabPanel.cs
+++ b/EmoTracker.Data/Layout/TabPanel.cs
@@ -152,7 +152,7 @@ namespace EmoTracker.Data.Layout
                         tab.OwnerState = this.OwnerState;
                         tab.SeedDefinition(
                             entry.GetValue<string>("title"),
-                            ImageReference.FromPackRelativePath(package, entry.GetValue<string>("icon"), entry.GetValue<string>("icon_image_spec")),
+                            ImageReference.FromPackRelativePath((this.OwnerState as Sessions.TrackerState)?.PackageInstance, entry.GetValue<string>("icon"), entry.GetValue<string>("icon_image_spec")),
                             layout);
                         mTabs.Add(tab);
                     }

--- a/EmoTracker.Data/LocationDatabase.cs
+++ b/EmoTracker.Data/LocationDatabase.cs
@@ -177,11 +177,11 @@ namespace EmoTracker.Data
 
         public void ParseLocationVisualProperties(JObject data, LocationVisualProperties visual, IGamePackage package)
         {
-            ImageReference openImg = ImageReference.FromPackRelativePath(package, data.GetValue<string>("chest_opened_img"));
+            ImageReference openImg = ImageReference.FromPackRelativePath(this.State?.PackageInstance, data.GetValue<string>("chest_opened_img"));
             if (openImg != null)
                 visual.OpenChestImage = openImg;
 
-            ImageReference closedImg = ImageReference.FromPackRelativePath(package, data.GetValue<string>("chest_unopened_img"));
+            ImageReference closedImg = ImageReference.FromPackRelativePath(this.State?.PackageInstance, data.GetValue<string>("chest_unopened_img"));
             if (closedImg != null)
                 visual.ClosedChestImage = closedImg;
 
@@ -723,7 +723,7 @@ namespace EmoTracker.Data
 
                     string thumbnailPath = sectionData.GetValue<string>("thumbnail");
                     if (!string.IsNullOrWhiteSpace(thumbnailPath))
-                        section.Thumbnail = ImageReference.FromPackRelativePath(package, thumbnailPath);
+                        section.Thumbnail = ImageReference.FromPackRelativePath(this.State?.PackageInstance, thumbnailPath);
 
                     section.HostedItemCode = sectionData.GetValue<string>("hosted_item");
                     section.GateItemCode = sectionData.GetValue<string>("gate_item");
@@ -1018,8 +1018,7 @@ namespace EmoTracker.Data
 
                             if (!string.IsNullOrEmpty(imagePath))
                             {
-                                var pkg = this.State?.PackageInstance?.GamePackage;
-                                ImageReference imageRef = ImageReference.FromPackRelativePath(pkg, imagePath, filter);
+                                ImageReference imageRef = ImageReference.FromPackRelativePath(this.State?.PackageInstance, imagePath, filter);
                                 if (imageRef != null)
                                     location.AddBadge(key, imageRef, null, ox, oy);
                             }

--- a/EmoTracker.Data/Locations/Location.cs
+++ b/EmoTracker.Data/Locations/Location.cs
@@ -521,9 +521,9 @@ namespace EmoTracker.Data.Locations
         {
             try
             {
-                var pkg = (this.OwnerState as Sessions.TrackerState)?.PackageInstance?.GamePackage
-                    ?? Sessions.ActiveSession.Primary?.PackageInstance?.GamePackage;
-                ImageReference badge = ImageReference.FromPackRelativePath(pkg, imageRef, filterSpec);
+                var pi = (this.OwnerState as Sessions.TrackerState)?.PackageInstance
+                    ?? Sessions.ActiveSession.Primary?.PackageInstance;
+                ImageReference badge = ImageReference.FromPackRelativePath(pi, imageRef, filterSpec);
                 if (badge == null) return null;
                 mBadges[DefaultBadgeKey] = new BadgeEntry(DefaultBadgeKey, badge);
                 return badge;

--- a/EmoTracker.Data/MapDatabase.cs
+++ b/EmoTracker.Data/MapDatabase.cs
@@ -78,7 +78,7 @@ namespace EmoTracker.Data
                                     mapObj.Name = map.GetValue<string>("name");
                                     mapObj.LocationSize = map.GetValue<double>("location_size", 70);
                                     mapObj.LocationBorderThickness = map.GetValue<double>("location_border_thickness", 8);
-                                    mapObj.Image = ImageReference.FromPackRelativePath(package, map.GetValue<string>("img"), map.GetValue<string>("img_mods"));
+                                    mapObj.Image = ImageReference.FromPackRelativePath(state?.PackageInstance, map.GetValue<string>("img"), map.GetValue<string>("img_mods"));
                                     mMaps.Add(mapObj);
                                 }
                             }

--- a/EmoTracker.Data/Media/ImageReference.cs
+++ b/EmoTracker.Data/Media/ImageReference.cs
@@ -251,10 +251,10 @@ namespace EmoTracker.Data.Media
 
         public static ImageReference FromPackRelativePath(string path, string filter = null)
         {
-            return FromPackRelativePath(Sessions.ActiveSession.Primary?.PackageInstance?.GamePackage, path, filter);
+            return FromPackRelativePath(Sessions.ActiveSession.Primary?.PackageInstance, path, filter);
         }
 
-        public static ImageReference FromPackRelativePath(IGamePackage package, string path, string filter = null)
+        public static ImageReference FromPackRelativePath(Sessions.PackageInstance pi, string path, string filter = null)
         {
             if (string.IsNullOrWhiteSpace(path))
                 return null;
@@ -262,6 +262,7 @@ namespace EmoTracker.Data.Media
             path = path.Trim();
             path = path.TrimStart(',', '/', '\\');
 
+            var package = pi?.GamePackage;
             if (package == null || !package.Exists(path))
                 return null;
 
@@ -274,13 +275,10 @@ namespace EmoTracker.Data.Media
             {
                 URI = new Uri(path),
                 Filter = filter,
-                // Phase 7.1.h: stamp the owning PackageInstance so the
-                // resolver can find this reference's cache + open the
-                // file directly without consulting an ambient session.
-                PackageInstance = Sessions.ActiveSession.FindPackageInstanceFor(package),
+                PackageInstance = pi,
             };
 
-            PopulateDimensions(result, package, result.PackageInstance?.ActiveVariant, path);
+            PopulateDimensions(result, package, pi?.ActiveVariant, path);
             NotifyCreated(result);
 
             return result;

--- a/EmoTracker.Data/ScriptManager.cs
+++ b/EmoTracker.Data/ScriptManager.cs
@@ -39,7 +39,7 @@ namespace EmoTracker.Data
 
         public ImageReference FromPackRelativePath(string path, string filter = null)
         {
-            return ImageReference.FromPackRelativePath(mState.PackageInstance?.GamePackage, path, filter);
+            return ImageReference.FromPackRelativePath(mState.PackageInstance, path, filter);
         }
 
         public ImageReference FromImageReference(ImageReference existingReference, string filter = null)


### PR DESCRIPTION
## Summary

- `ImageReference.FromPackRelativePath` now accepts `Sessions.PackageInstance` directly instead of `IGamePackage`
- Each call site derives `pi` from `this.OwnerState` (or the already-available `state` parameter) — no method signature changes in the parse chain
- Eliminates the ambient `PackageInstanceForPackageResolver` lookup, which used `FirstOrDefault` and ignored variant identity, causing all `ImageReference`s created during a variant-B load to be stamped with variant-A's `PackageInstance`

## Root cause

`ActiveSession.PackageInstanceForPackageResolver` resolved a PI by matching only on `IGamePackage` reference (`FirstOrDefault`). When variant B was loaded for a pack that already had variant A's PI registered, every new `ImageReference` was stamped with PI_A — so the image cache for the new variant was never consulted and images were always one variant behind.

## Test plan

- [ ] Load a pack that has multiple variants
- [ ] Switch variants and confirm images update immediately to the new variant
- [ ] Switch back to the original variant and confirm images are correct

Fixes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)