### PR TITLE
Fix memory leak when opening a save or reloading a pack (#84)

### DIFF
--- a/EmoTracker.Data/Sessions/PackageInstance.cs
+++ b/EmoTracker.Data/Sessions/PackageInstance.cs
@@ -189,6 +189,24 @@ namespace EmoTracker.Data.Sessions
             return mStates.TryGetValue(stateId, out var state) ? state : null;
         }
 
+        /// <summary>
+        /// Transfers <paramref name="state"/> from this PackageInstance to
+        /// <paramref name="destination"/> without firing lifecycle events or
+        /// disposing anything. Used by <c>ApplicationModel.LoadProgress</c>
+        /// when a save-file load creates a new PI: the existing primary state
+        /// is moved to the new PI so the old PI can be safely disposed without
+        /// touching the still-live state.
+        /// </summary>
+        internal void MigrateStateTo(TrackerState state, PackageInstance destination)
+        {
+            if (state == null) throw new ArgumentNullException(nameof(state));
+            if (destination == null) throw new ArgumentNullException(nameof(destination));
+            if (mStates.Remove(state.Id))
+                destination.mStates[state.Id] = state;
+            // state.PackageInstance is already pointing at destination —
+            // TrackerState.LoadProgress set it before calling LoadInto.
+        }
+
         public override void Dispose()
         {
             // Tear down the live states first, then the definitional state.

--- a/EmoTracker.Data/Sessions/PackageLoader.cs
+++ b/EmoTracker.Data/Sessions/PackageLoader.cs
@@ -223,6 +223,8 @@ namespace EmoTracker.Data.Sessions
                     (kvp.Value as IDisposable)?.Dispose();
                 pi.SourceImageCache.Clear();
             }
+            foreach (var kvp in pi.ImageCache)
+                (kvp.Value as IDisposable)?.Dispose();
             pi.ImageCache.Clear();
         }
 

--- a/EmoTracker.Data/Sessions/PackageLoader.cs
+++ b/EmoTracker.Data/Sessions/PackageLoader.cs
@@ -76,6 +76,14 @@ namespace EmoTracker.Data.Sessions
         static bool mInProgress;
 
         /// <summary>
+        /// True while <see cref="LoadInto"/> is executing on this thread.
+        /// Used by <see cref="ApplicationSettings.SyncSeedsFromSession"/> to
+        /// suppress seed-writes driven by pack-script (init.lua) changes,
+        /// so only explicit user UI changes update the saved defaults.
+        /// </summary>
+        internal static bool IsLoading => mInProgress;
+
+        /// <summary>
         /// Loads <paramref name="package"/> (with optional <paramref name="variant"/>)
         /// into <paramref name="target"/>'s catalogs. Caller is responsible for
         /// having the <c>target</c>'s catalogs already wired (the
@@ -125,6 +133,13 @@ namespace EmoTracker.Data.Sessions
                 target.Locations.Reset();
                 target.Items.Reset();
                 target.Scripts.Reset();
+
+                // Flush the PackageInstance's decoded-image caches. Old
+                // ImageReference keys from the now-reset catalogs would
+                // otherwise keep both the source SKBitmaps and the resolved
+                // IImages alive across every Reload, accumulating ~250 MB per
+                // reload for large packs.
+                FlushImageCaches(target.PackageInstance);
 
                 ApplicationColors.Instance.LoadColors();
 
@@ -194,6 +209,21 @@ namespace EmoTracker.Data.Sessions
                     }
                 }
             }
+        }
+
+        // Dispose and clear both image caches on a PackageInstance. Called
+        // before each load so stale SKBitmaps and resolved IImages from the
+        // previous load are released rather than accumulated in memory.
+        static void FlushImageCaches(PackageInstance pi)
+        {
+            if (pi == null) return;
+            lock (pi.SourceImageCacheLock)
+            {
+                foreach (var kvp in pi.SourceImageCache)
+                    (kvp.Value as IDisposable)?.Dispose();
+                pi.SourceImageCache.Clear();
+            }
+            pi.ImageCache.Clear();
         }
 
         // Phase 7.1.g: pack-driven UI flags now live on the per-state

--- a/EmoTracker.UI/Media/Utility/IconUtility.cs
+++ b/EmoTracker.UI/Media/Utility/IconUtility.cs
@@ -48,17 +48,19 @@ namespace EmoTracker.UI.Media.Utility
         // ── Avalonia / SkiaSharp image pipeline ──────────────────────────────────
 
         // Alpha masks keyed by IImage: bool[] of length (width * height), true = opaque.
-        // ConcurrentDictionary because the background image worker writes masks while
-        // the UI thread reads them (InputMaskingImage.HitTest via GetAlphaMask).
-        private static readonly System.Collections.Concurrent.ConcurrentDictionary<IImage, (bool[] mask, int w, int h)> sAlphaMasks = new();
+        // ConditionalWeakTable so entries are freed automatically when the IImage key
+        // becomes unreachable (e.g. after a pack reload clears PackageInstance.ImageCache).
+        // All public CWT members are thread-safe.
+        private sealed class AlphaMaskEntry { public bool[] Pixels; public int Width, Height; }
+        private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<IImage, AlphaMaskEntry> sAlphaMasks = new();
 
         // Cached Skia-encoded PNG bytes for each IImage produced by SkToAvalonia.
         // Used by ToSkBitmap to bypass Avalonia's Bitmap.Save(Stream), which may strip the
         // alpha channel on some platforms — causing overlay compositing to treat every pixel
         // as fully opaque and completely hide the base layer.
-        // ConcurrentDictionary because the background image worker writes entries while
-        // filter resolution may read them concurrently.
-        private static readonly System.Collections.Concurrent.ConcurrentDictionary<IImage, byte[]> sPngCache = new();
+        // ConditionalWeakTable so entries are freed automatically when the IImage key
+        // becomes unreachable, preventing static accumulation across pack reloads.
+        private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<IImage, byte[]> sPngCache = new();
 
         // HTTP/HTTPS image download cache. null value means "download in progress".
         private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, IImage?> sHttpCache = new();
@@ -74,7 +76,7 @@ namespace EmoTracker.UI.Media.Utility
         public static (bool[] mask, int w, int h)? GetAlphaMask(IImage image)
         {
             if (image != null && sAlphaMasks.TryGetValue(image, out var entry))
-                return entry;
+                return (entry.Pixels, entry.Width, entry.Height);
             return null;
         }
 
@@ -231,7 +233,7 @@ namespace EmoTracker.UI.Media.Utility
             {
                 var mask = ComputeAlphaMask(bmp);
                 var avBitmap = SkToAvaloniaCore(bmp);
-                sAlphaMasks[avBitmap] = (mask, bmp.Width, bmp.Height);
+                sAlphaMasks.AddOrUpdate(avBitmap, new AlphaMaskEntry { Pixels = mask, Width = bmp.Width, Height = bmp.Height });
                 bmp.Dispose();
                 return avBitmap;
             }
@@ -250,7 +252,7 @@ namespace EmoTracker.UI.Media.Utility
             if (storeMask)
             {
                 var mask = ComputeAlphaMask(bmp);
-                sAlphaMasks[avBitmap] = (mask, bmp.Width, bmp.Height);
+                sAlphaMasks.AddOrUpdate(avBitmap, new AlphaMaskEntry { Pixels = mask, Width = bmp.Width, Height = bmp.Height });
             }
 
             return avBitmap;
@@ -267,7 +269,7 @@ namespace EmoTracker.UI.Media.Utility
             byte[] pngBytes = encoded.ToArray();
             var avBitmap = new Avalonia.Media.Imaging.Bitmap(new MemoryStream(pngBytes));
 
-            sPngCache[avBitmap] = pngBytes;
+            sPngCache.AddOrUpdate(avBitmap, pngBytes);
 
             return avBitmap;
         }

--- a/EmoTracker/ApplicationModel.cs
+++ b/EmoTracker/ApplicationModel.cs
@@ -1549,6 +1549,11 @@ Failed to save workspace to ```{0}```.
             var target = PrimaryState;
             if (target == null) return false;
 
+            // Snapshot the PI before the load. TrackerState.LoadProgress creates
+            // a brand-new PackageInstance for the save's (pack, variant), leaving
+            // the old one stranded in mPackageInstances and never disposed.
+            var oldPi = target.PackageInstance;
+
             if (target.LoadProgress(path, (JObject root) =>
             {
                 WindowService.Instance.MainWindowWidth = root.GetValue<double>("main_window_width", WindowService.Instance.MainWindowWidth);
@@ -1566,6 +1571,21 @@ Failed to save workspace to ```{0}```.
                 }
             }))
             {
+                // If LoadProgress swapped to a new PI, transfer the state so
+                // the old PI can be cleanly disposed (freeing its image caches,
+                // definitional state, and Lua interpreter — ~600 MB for large packs).
+                var newPi = target.PackageInstance;
+                if (!ReferenceEquals(oldPi, newPi))
+                {
+                    oldPi?.MigrateStateTo(target, newPi);
+                    mPackageInstances.Add(newPi);
+                    if (ReferenceEquals(mActivePackageInstance, oldPi))
+                        ActivePackageInstance = newPi;
+                    mPackageInstances.Remove(oldPi);
+                    if (oldPi != null && oldPi.States.Count == 0)
+                        oldPi.Dispose();
+                }
+
                 AcquireLayouts();
                 // Phase 7.11 polish: a freshly-loaded state isn't dirty
                 // — clear the modified marker for the active state.


### PR DESCRIPTION
## Summary

Fixes two distinct memory leaks reported in #84 (large packs, Linux 3.0.3.1):

- **~600 MB per save-open** — `TrackerState.LoadProgress()` created a fresh `PackageInstance` for the save's (pack, variant) but the old PI was never disposed, leaving its image caches, Lua state, and definitional `TrackerState` alive indefinitely. Fix: `ApplicationModel.LoadProgress()` now detects the PI change, migrates the primary state to the new PI via the new `PackageInstance.MigrateStateTo()`, and disposes the old PI.

- **~250 MB per reload** — `PackageLoader.LoadInto()` reset the item/location catalogs but left `PackageInstance.ImageCache` and `SourceImageCache` intact. Old `ImageReference` keys from the reset catalogs kept decoded `SKBitmap`s and `IImage`s alive across every reload. Fix: flush both caches after the catalog resets in `PackageLoader.LoadInto()`.

- **Static cache accumulation (compounding)** — `IconUtility.sPngCache` and `sAlphaMasks` used `ConcurrentDictionary` with strong `IImage` references as keys, preventing `Avalonia.Bitmap` objects from being GC'd even after the PI's `ImageCache` was cleared. Fix: switch both to `ConditionalWeakTable` so entries are evicted automatically when the `IImage` key becomes unreachable.

## Files changed

| File | Change |
|------|--------|
| `PackageInstance.cs` | Add `MigrateStateTo()` to transfer a state between PIs without disposal |
| `ApplicationModel.cs` | `LoadProgress()` detects PI change and disposes old PI |
| `PackageLoader.cs` | Flush image caches after catalog resets; extract `FlushImageCaches()` helper |
| `IconUtility.cs` | `sPngCache`/`sAlphaMasks` → `ConditionalWeakTable` for automatic eviction |

## Test plan

- [ ] Open a large pack (e.g. ALBWR tracker), note memory usage (~1.0 GB baseline)
- [ ] Open a save file — confirm memory does **not** increase by ~600 MB; should stay near baseline after GC
- [ ] Reload the pack several times — confirm memory does **not** grow ~250 MB per reload
- [ ] Open additional save files repeatedly — confirm memory stays stable
- [ ] Confirm items/images render correctly after each open/reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)