### PR TITLE
Persist tracking settings as defaults; seed on new pack load

### DIFF
--- a/EmoTracker.Data/ApplicationSettings.cs
+++ b/EmoTracker.Data/ApplicationSettings.cs
@@ -86,6 +86,10 @@ namespace EmoTracker.Data
         /// Called from <see cref="Sessions.TrackerState"/>'s adoption ctor
         /// so a primary state inherits the user's pre-existing preferences
         /// loaded from <c>ApplicationSettings.json</c>.
+        /// Also called from <see cref="Sessions.TrackerState.ActivatePackage"/>
+        /// to reset settings to the saved defaults before init.lua runs,
+        /// ensuring pack scripts start from the user's preferences and may
+        /// optionally override them.
         /// </summary>
         internal void SeedIntoSession(Sessions.SessionSettings target)
         {
@@ -95,6 +99,54 @@ namespace EmoTracker.Data
             target.AlwaysAllowClearing = mbSeedAlwaysAllowClearing;
             target.AutoUnpinLocationsOnClear = mbSeedAutoUnpinLocationsOnClear;
             target.PinLocationsOnItemCapture = mbSeedPinLocationsOnItemCapture;
+        }
+
+        /// <summary>
+        /// Called by <see cref="Sessions.SessionSettings"/> when a tracked
+        /// property changes, so UI-driven setting changes are persisted to
+        /// <c>ApplicationSettings.json</c> as the new defaults for future
+        /// sessions / pack loads.
+        ///
+        /// <para>
+        /// No-ops when called while a pack is loading (i.e.
+        /// <see cref="Sessions.PackageLoader.IsLoading"/> is true) to avoid
+        /// init.lua-driven changes overwriting the user's saved preferences.
+        /// </para>
+        /// </summary>
+        internal void SyncSeedsFromSession(Sessions.SessionSettings source)
+        {
+            if (source == null) return;
+            if (Sessions.PackageLoader.IsLoading) return;
+
+            bool changed = false;
+            if (mbSeedIgnoreAllLogic != source.IgnoreAllLogic)
+            {
+                mbSeedIgnoreAllLogic = source.IgnoreAllLogic;
+                changed = true;
+            }
+            if (mbSeedDisplayAllLocations != source.DisplayAllLocations)
+            {
+                mbSeedDisplayAllLocations = source.DisplayAllLocations;
+                changed = true;
+            }
+            if (mbSeedAlwaysAllowClearing != source.AlwaysAllowClearing)
+            {
+                mbSeedAlwaysAllowClearing = source.AlwaysAllowClearing;
+                changed = true;
+            }
+            if (mbSeedAutoUnpinLocationsOnClear != source.AutoUnpinLocationsOnClear)
+            {
+                mbSeedAutoUnpinLocationsOnClear = source.AutoUnpinLocationsOnClear;
+                changed = true;
+            }
+            if (mbSeedPinLocationsOnItemCapture != source.PinLocationsOnItemCapture)
+            {
+                mbSeedPinLocationsOnItemCapture = source.PinLocationsOnItemCapture;
+                changed = true;
+            }
+
+            if (changed)
+                WriteSettings();
         }
 
         public bool IgnoreAllLogic

--- a/EmoTracker.Data/Sessions/PackageLoader.cs
+++ b/EmoTracker.Data/Sessions/PackageLoader.cs
@@ -76,6 +76,14 @@ namespace EmoTracker.Data.Sessions
         static bool mInProgress;
 
         /// <summary>
+        /// True while <see cref="LoadInto"/> is executing on this thread.
+        /// Used by <see cref="ApplicationSettings.SyncSeedsFromSession"/> to
+        /// suppress seed-writes driven by pack-script (init.lua) changes,
+        /// so only explicit user UI changes update the saved defaults.
+        /// </summary>
+        internal static bool IsLoading => mInProgress;
+
+        /// <summary>
         /// Loads <paramref name="package"/> (with optional <paramref name="variant"/>)
         /// into <paramref name="target"/>'s catalogs. Caller is responsible for
         /// having the <c>target</c>'s catalogs already wired (the

--- a/EmoTracker.Data/Sessions/SessionSettings.cs
+++ b/EmoTracker.Data/Sessions/SessionSettings.cs
@@ -54,15 +54,19 @@ namespace EmoTracker.Data.Sessions
         public partial bool IgnoreAllLogic { get; set; }
 
         [KVMutable]
+        [OnChanged(nameof(SyncSeedsToApplicationSettings))]
         public partial bool DisplayAllLocations { get; set; }
 
         [KVMutable]
+        [OnChanged(nameof(SyncSeedsToApplicationSettings))]
         public partial bool AlwaysAllowClearing { get; set; }
 
         [KVMutable]
+        [OnChanged(nameof(SyncSeedsToApplicationSettings))]
         public partial bool AutoUnpinLocationsOnClear { get; set; }
 
         [KVMutable]
+        [OnChanged(nameof(SyncSeedsToApplicationSettings))]
         public partial bool PinLocationsOnItemCapture { get; set; }
 
         [KVMutable]
@@ -111,6 +115,12 @@ namespace EmoTracker.Data.Sessions
             // ApplicationSettings.IgnoreAllLogic's setter.
             var state = OwnerState as TrackerState;
             state?.Locations.RefreshAccessibility();
+            SyncSeedsToApplicationSettings();
+        }
+
+        protected void SyncSeedsToApplicationSettings()
+        {
+            ApplicationSettings.Instance?.SyncSeedsFromSession(this);
         }
 
         // ----------- Fork support ---------------------------------------------

--- a/EmoTracker.Data/Sessions/TrackerState.PackageOps.cs
+++ b/EmoTracker.Data/Sessions/TrackerState.PackageOps.cs
@@ -134,6 +134,11 @@ namespace EmoTracker.Data.Sessions
                 PackageManager.Instance.RefreshActiveState();
                 NotifyPropertyChanged(nameof(ActiveVariantUID));
 
+                // Reset tracking settings to the user's saved defaults before
+                // running init.lua, so pack scripts start from the user's
+                // preferences and may optionally override them (issue #83).
+                ApplicationSettings.Instance.SeedIntoSession(Settings);
+
                 PackageLoader.LoadInto(this, package, variant);
             }
             finally


### PR DESCRIPTION
Fixes #83.

## Summary

- **Persist UI changes**: When the user toggles a tracking setting (Ignore All Logic, Show All Locations, Always Allow Clearing, Auto-unpin on Clear, Pin on Item Capture) via the menu, the change now propagates back to `ApplicationSettings`' seed fields and writes to `application_settings.json`. Previously, UI bindings went directly to `SessionSettings` bypassing the seed, so preferences were lost on restart.

- **Seed on new pack/variant load**: `ActivatePackage` now calls `SeedIntoSession` before `PackageLoader.LoadInto`, so the state's settings are reset to the user's saved defaults before `init.lua` runs. Pack scripts can still override them during initialization.

- **Guard against init.lua overwriting seeds**: `SyncSeedsFromSession` no-ops when `PackageLoader.IsLoading` is true, so pack-script-driven setting changes don't clobber the user's saved preferences.

- **Reload is unchanged**: `Reload()` does not seed — reloading the same pack preserves the current session settings.

## Changes

| File | What changed |
|------|--------------|
| `PackageLoader.cs` | Added `internal static bool IsLoading` (exposes the existing `[ThreadStatic] mInProgress` flag) |
| `ApplicationSettings.cs` | Added `SyncSeedsFromSession`: updates seed fields + writes JSON, guarded by `IsLoading` |
| `SessionSettings.cs` | Added `[OnChanged(SyncSeedsToApplicationSettings)]` to the 4 settings without hooks; `OnIgnoreAllLogicChanged` also calls the sync method |
| `TrackerState.PackageOps.cs` | `ActivatePackage` calls `SeedIntoSession(Settings)` before `LoadInto` |

## Test plan

- [ ] Toggle "Ignore All Logic" on → restart app → setting should still be on
- [ ] Toggle "Show All Locations" → restart → persists
- [ ] Load pack A with "Ignore All Logic" on → settings seeded correctly before init.lua
- [ ] Switch variant → settings reset to saved defaults before init.lua runs
- [ ] Reload pack (Refresh) → current settings preserved, not reset to defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)