### PR TITLE
Fix autotracker period throttle, Dirty flag, and Lua debugger exception pause

### DIFF
--- a/EmoTracker.Data/AutoTracking/LuaMemorySegment.cs
+++ b/EmoTracker.Data/AutoTracking/LuaMemorySegment.cs
@@ -58,8 +58,6 @@ namespace EmoTracker.Data.AutoTracking
 
         protected override void OnSegmentDataUpdated()
         {
-            base.OnSegmentDataUpdated();
-
             var state = this.OwnerState as Sessions.TrackerState;
             if (state == null) return;
             var scripts = state.Scripts;
@@ -76,10 +74,15 @@ namespace EmoTracker.Data.AutoTracking
             {
                 try
                 {
+                    object[] result;
                     using (new LocationDatabase.SuspendRefreshScope(state.Locations))
                     {
-                        scripts.SafeCall(callback, this);
+                        result = scripts.SafeCall(callback, this);
                     }
+                    bool succeeded = result != null && result.Length > 0
+                        && result[0] != null && !(result[0] is bool b && !b);
+                    if (succeeded)
+                        Dirty = false;
                 }
                 catch (Exception ex)
                 {

--- a/EmoTracker.Data/AutoTracking/MemorySegment.cs
+++ b/EmoTracker.Data/AutoTracking/MemorySegment.cs
@@ -33,7 +33,7 @@ namespace EmoTracker.Data.AutoTracking
     /// data (override <see cref="OnSegmentDataUpdated"/>).
     /// </para>
     /// </summary>
-    public class MemorySegment : ModelTypeBase, IMemorySegment, IUpdateWithConnector, IDisposable
+    public abstract class MemorySegment : ModelTypeBase, IMemorySegment, IUpdateWithConnector, IDisposable
     {
         #region -- Global Event Hooks --
 
@@ -339,9 +339,7 @@ namespace EmoTracker.Data.AutoTracking
         /// overrides to dispatch onto the UI thread and SafeCall the
         /// pack-supplied LuaFunction callback.
         /// </summary>
-        protected virtual void OnSegmentDataUpdated()
-        {
-        }
+        protected abstract void OnSegmentDataUpdated();
 
         public override void Dispose()
         {

--- a/EmoTracker.Data/Debugging/LuaDebuggee.cs
+++ b/EmoTracker.Data/Debugging/LuaDebuggee.cs
@@ -667,6 +667,8 @@ namespace EmoTracker.Data.Debugging
 
         internal void EnterExceptionPause(string errMessage, string traceback)
         {
+            if (!(LuaDebugServer.Instance?.HasActiveSession ?? false)) return;
+
             // Always log so we can confirm the upcall actually
             // reached us — the Lua-side handler's pcall around the
             // upcall would otherwise silently swallow any throw.


### PR DESCRIPTION
## Summary

- **`MemorySegment.ShouldUpdate`**: fixed an inverted `CompareTo` sign (`> 0` → `< 0`) that caused memory segments to update on every 30 ms poll tick until the period elapsed, then never update again — the exact opposite of the intended throttle behavior. `MemoryTimer` had the correct sign the whole time.
- **`LuaMemorySegment`**: the Lua callback's return value is now captured; a truthy result clears `Dirty` so normal period-based throttling resumes after each successful update. Previously `Dirty` was never cleared.
- **`LuaDebuggee.EnterExceptionPause`**: added an early-out guard (`HasActiveSession`) so Lua errors at runtime don't enter the DAP exception-pause path — including its log line — when no debugger is attached.
- **`MemorySegment`**: made abstract (was already effectively abstract via the `OnSegmentDataUpdated` virtual no-op).

## Test plan

- [ ] Connect an autotracker and verify memory segment callbacks fire at their configured period (not every 30 ms)
- [ ] Confirm a segment with a returning-`true` callback stops showing as dirty after the first successful update
- [ ] Trigger a Lua error with no DAP debugger attached — confirm no `EnterExceptionPause` log line appears
- [ ] Trigger a Lua error with a DAP debugger attached and exception-break enabled — confirm pause still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)