### PR TITLE
Fix autotracker reload lockup, stale state, and NWA address map detection (#93)

### DIFF
--- a/EmoTracker.Data/AutoTracking/LuaMemorySegment.cs
+++ b/EmoTracker.Data/AutoTracking/LuaMemorySegment.cs
@@ -62,8 +62,7 @@ namespace EmoTracker.Data.AutoTracking
             if (state == null) return;
             var scripts = state.Scripts;
             if (scripts == null) return;
-            var callback = mCallback;
-            if (callback == null) return;
+            if (mCallback == null) return;
 
             // Memory polling fires on a worker thread. The callback may
             // mutate items / locations, both of which expect UI-thread
@@ -74,10 +73,19 @@ namespace EmoTracker.Data.AutoTracking
             {
                 try
                 {
+                    // Re-read mCallback at execution time. A pack reload
+                    // between the queue-time check above and now would have
+                    // torn down our Lua state and called Dispose() on this
+                    // segment (which nulls mCallback). Invoking SafeCall
+                    // with a LuaFunction whose underlying state is closed
+                    // hangs the UI thread inside NLua — issue #93.
+                    var liveCallback = mCallback;
+                    if (liveCallback == null) return;
+                    if (!scripts.IsLuaLoaded) return;
                     object[] result;
                     using (new LocationDatabase.SuspendRefreshScope(state.Locations))
                     {
-                        result = scripts.SafeCall(callback, this);
+                        result = scripts.SafeCall(liveCallback, this);
                     }
                     bool succeeded = result != null && result.Length > 0
                         && result[0] != null && !(result[0] is bool b && !b);

--- a/EmoTracker/Extensions/AutoTracker/AutoTrackerExtension.cs
+++ b/EmoTracker/Extensions/AutoTracker/AutoTrackerExtension.cs
@@ -186,27 +186,28 @@ namespace EmoTracker.Extensions.AutoTracker
             if (!ReferenceEquals(e.Target, mState)) return;
 
             // The state's Lua interpreter is about to be Reset() — close +
-            // re-open. Drop our memory segments now so we don't carry
-            // callbacks that reference the soon-to-be-closed interpreter.
-            // StopAutoTracking first to drain any in-flight poll cleanly;
-            // the active provider connection itself is preserved (the user
-            // chose to stay connected across reloads), but the watch list
-            // is rebuilt by the new init.lua's AddMemoryWatch calls.
+            // re-open. Fully stop autotracking before the reload: keeping
+            // the connection alive across reload left the extension stuck
+            // in an "active/running" state that didn't actually refresh
+            // (the new pack's init.lua re-registers watches against the
+            // new Lua state, but the throttle / dirty bookkeeping carried
+            // from the old run prevents updates from landing until the
+            // user manually stops and restarts).
             //
-            // Without this hook, the next memory poll after reload+
-            // reconnect invokes SafeCall on a LuaFunction whose underlying
-            // Lua state is closed, which hangs the UI thread inside NLua.
-            bool wasConnected = ActiveProvider != null;
-            var preservedProvider = SelectedProvider;
-
-            // Drain in-flight + dispose stale segments. Note Clear() also
-            // clears the pending update queue.
+            // StopAutoTracking drains any in-flight poll, disconnects the
+            // active provider, and fires the AutoTrackerStopped callback.
+            // Clear() then drops the pending-update queue. The user will
+            // re-Start once the pack finishes loading.
+            StopAutoTracking();
             Clear();
 
-            // Restore the connection target so the user doesn't have to
-            // re-pick it after init.lua repopulates the watch list.
-            if (preservedProvider != null)
-                SelectedProvider = preservedProvider;
+            // Surface the now-stopped state to bindings; OnAnyPackageLoad-
+            // Complete will re-emit these too once new segments / timers
+            // are registered, but raise them here so the status bar
+            // reflects "not running" during the reload window rather than
+            // showing stale running state.
+            NotifyPropertyChanged(nameof(Active));
+            NotifyPropertyChanged(nameof(StatusBarControl));
         }
 
         void OnAnyPackageLoadComplete(object sender, EmoTracker.Data.Sessions.PackageLoader.PackageLoadEventArgs e)

--- a/EmoTracker/Providers/NWA/NwaDevice.cs
+++ b/EmoTracker/Providers/NWA/NwaDevice.cs
@@ -190,7 +190,7 @@ namespace EmoTracker.Providers.NWA
         /// </summary>
         async Task<byte[]> ReadRawDomainAsync(string domain, ulong offset, int length)
         {
-            string command = $"CORE_READ {domain} ${offset:X};${length:X}";
+            string command = $"CORE_READ {domain};${offset:X};${length:X}";
             byte[] data = await SendReadCommandAsync(command).ConfigureAwait(false);
             return data ?? Array.Empty<byte>();
         }


### PR DESCRIPTION
## Summary
Fixes [#93](https://github.com/EmoTracker-Community/EmoTracker/issues/93) (UI lockup when reloading pack with autotracker connected) plus two related issues uncovered while investigating it.

- **`AutoTrackerExtension.OnAnyPackageLoadStarting`** — fully stop autotracking on pack reload (drain in-flight poll, disconnect active provider, fire `AutoTrackerStopped`, raise `Active` / `StatusBarControl` notifications). Previously the connection was preserved across reload, leaving the extension stuck in an "active/running" state that didn't actually refresh until the user manually stopped and restarted.
- **`LuaMemorySegment.OnSegmentDataUpdated`** — re-read `mCallback` inside the dispatched lambda and check `ScriptManager.IsLuaLoaded` before calling `SafeCall`. A `Dispatch.BeginInvoke` posted from an in-flight poll just before reload would otherwise land after `ScriptManager.Reset` closed the Lua state and invoke a `LuaFunction` against a closed state — which hangs the UI thread inside NLua. This is the root-cause hang from #93; the null-check is defense-in-depth in case any dispatched callback slips past the new full-stop.
- **`NwaDevice.ReadRawDomainAsync`** — replace stray space with the protocol's `;` separator in the `CORE_READ` command used by the SNES address-map initializer. The malformed command was rejected by snes9x-nwa as a protocol error, causing ROM-header reads to throw and SNES layout detection to silently fall back to LoROM regardless of cartridge mapping.

The reload-handler change is scoped to the state being reloaded — multi-tab/multi-window setups continue polling on their other tabs undisturbed (the existing `ReferenceEquals(e.Target, mState)` guard).

## Test plan
- [ ] Reload pack while autotracker is connected → no UI lockup; status bar shows stopped; clicking Start reconnects and resumes polling.
- [ ] Reload pack on tab B while tabs A and C also have autotracker running → only B stops; A and C keep polling.
- [ ] Connect via NWA to snes9x-nwa with a HiROM cartridge → log shows `Detected ROM layout: HiROM` instead of `LoROM`; pack reads land on the correct ROM offsets.
- [ ] Connect via NWA with an ExHiROM cartridge → detection picks ExHiROM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)