### PR TITLE
Allow connection for devices that don't have SNI mapping_detect implemented

### DIFF
--- a/EmoTracker/Providers/SNI/SniDevice.cs
+++ b/EmoTracker/Providers/SNI/SniDevice.cs
@@ -81,8 +81,7 @@ namespace EmoTracker.Providers.SNI
                 }).ConfigureAwait(false);
 
                 mDetectedMapping = detectResponse.MemoryMapping;
-                Log.Debug("[SNI] Connected to {DisplayName}, detected mapping: {Mapping}", mDisplayName,
-                    mDetectedMapping);
+                Log.Debug("[SNI] Connected to {DisplayName}, detected mapping: {Mapping}", mDisplayName, mDetectedMapping);
                 mConnected = true;
                 ConnectionStatusChanged?.Invoke(this, true);
             }

--- a/EmoTracker/Providers/SNI/SniDevice.cs
+++ b/EmoTracker/Providers/SNI/SniDevice.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Grpc.Core;
 
 namespace EmoTracker.Providers.SNI
 {
@@ -80,7 +81,18 @@ namespace EmoTracker.Providers.SNI
                 }).ConfigureAwait(false);
 
                 mDetectedMapping = detectResponse.MemoryMapping;
-                Log.Debug("[SNI] Connected to {DisplayName}, detected mapping: {Mapping}", mDisplayName, mDetectedMapping);
+                Log.Debug("[SNI] Connected to {DisplayName}, detected mapping: {Mapping}", mDisplayName,
+                    mDetectedMapping);
+                mConnected = true;
+                ConnectionStatusChanged?.Invoke(this, true);
+            }
+            catch (RpcException ex)
+            {
+                //SNI Memory Mapping Detection isn't implemented for these devices, but we are connected if we're getting this response
+                if(ex.StatusCode == StatusCode.Unimplemented) 
+                    Log.Debug("[SNI] Device does not implement mapping_detect however we are connected as we " +
+                              "explicitly received the Unimplemented status {DisplayName}: {Message}", 
+                        mDisplayName, ex.Message);
                 mConnected = true;
                 ConnectionStatusChanged?.Invoke(this, true);
             }


### PR DESCRIPTION
For some SNI distributions, such as the currently in testing MiSTerFPGA implementation, the SNI mapping_detect functionality is not implemented. See: https://github.com/NobodyNada/snid/blob/530b1ad2a9a29219ba0431f1c8ddee14cc61c286/src/server/sni/mod.rs#L173

When we receive a well formed error with the status explicitly "Unimplemented," we can assume the device is connected for users of said devices. However, they will have to know to explicitly change the Memory Mapping if their game requires until mapping_detect is implemented, if possible. 

Tested with Map Rando on a MiSTerFPGA, and this implementation was done in a way that hopefully won't cause any issues with other already tested platforms 